### PR TITLE
haml dependency seems overly specific at 4.0.3, made >= 4.0

### DIFF
--- a/haml-lint.gemspec
+++ b/haml-lint.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_dependency 'colorize', '0.5.8'
-  s.add_dependency 'haml', '4.0.3'
+  s.add_dependency 'haml', '>= 4.0'
   s.add_dependency 'rubocop', '>= 0.16.0'
 
   s.add_development_dependency 'rspec', '2.13.0'


### PR DESCRIPTION
Unable to install alongside html2haml because of different specific version requirements.

Doesn't seem 4.0.3 has any change that matters, so >= 4.0 should be good.. >= 4.0.3 would suffice if a known bug was fixed in 4.0.3
