### PR TITLE
ignore FileName rubocop cop

### DIFF
--- a/lib/haml_lint/linter/ruby_script.rb
+++ b/lib/haml_lint/linter/ruby_script.rb
@@ -45,12 +45,13 @@ module HamlLint
       BlockAlignment
       BlockNesting
       EndAlignment
-      IndentationWidth
+      FileName
       IfUnlessModifier
+      IndentationWidth
       LineLength
       TrailingWhitespace
-      WhileUntilModifier
       Void
+      WhileUntilModifier
     ]
 
     def extract_lints_from_offences(offences)


### PR DESCRIPTION
The FileName cop is coming in the next release of rubocop and checks the filename of the source files. Since haml-lint uses a temporary file its always invalid.

Sorted list of cops by name.
