### PR TITLE
Fix loading correct .rubocop.yml config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * Ignore the `FileName` Rubocop cop
+* Fix loading correct .rubocop.yml config
 
 ## 0.4.1
 

--- a/lib/haml_lint/linter/ruby_script.rb
+++ b/lib/haml_lint/linter/ruby_script.rb
@@ -24,9 +24,11 @@ module HamlLint
   private
 
     def find_lints(code)
-      original_filename = "#{File.basename(@parser.filename)}_" if @parser.filename
+      original_filename = @parser.filename || 'ruby_script'
+      filename = "#{File.basename(original_filename)}.haml_lint.tmp"
+      directory = File.dirname(original_filename)
 
-      Tempfile.open("haml-lint_#{original_filename}extracted_code") do |f|
+      Tempfile.open(filename, directory) do |f|
         f.write(code)
         f.close
         extract_lints_from_offences(lint_file(f.path))


### PR DESCRIPTION
The problem was caused by the fact that haml-lint creates temporary Ruby
files which is passed to Rubocop. The temporary files was outside of the
repository (tmp folder), so Rubocop doesn't pick up the corresponding
.rubocop.yml. Now the temporary file is places next to the haml file.
