### PR TITLE
Exclude Next cop from ruby linter

### DIFF
--- a/lib/haml_lint/linter/ruby_script.rb
+++ b/lib/haml_lint/linter/ruby_script.rb
@@ -55,6 +55,7 @@ module HamlLint
       IfUnlessModifier
       IndentationWidth
       LineLength
+      Next
       TrailingWhitespace
       Void
       WhileUntilModifier


### PR DESCRIPTION
`next` in views seams to cause problems - so this cop should be excluded.
