### PR TITLE
fix sorting issue with line number nil

### DIFF
--- a/lib/haml_lint/cli.rb
+++ b/lib/haml_lint/cli.rb
@@ -75,7 +75,7 @@ module HamlLint
     end
 
     def report_lints(lints)
-      sorted_lints = lints.sort_by { |l| [l.filename, l.line] }
+      sorted_lints = lints.sort_by { |l| [l.filename, l.line || 0] }
       reporter = options.fetch(:reporter, Reporter::DefaultReporter).new(sorted_lints)
       output = reporter.report_lints
       print output if output

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -156,4 +156,26 @@ describe HamlLint::CLI do
       end
     end
   end
+
+  describe '#report_lints' do
+    context 'when the same file has 2 errors but only one line' do
+      let(:filenames)    { ['some-filename.haml', 'some-filename.haml'] }
+      let(:lines)        { [502, nil] }
+      let(:descriptions) { ['Description of lint 1', 'Description of lint 2'] }
+      let(:severities)   { [:warning] * 2 }
+
+      let(:lints) do
+        filenames.each_with_index.map do |filename, index|
+          HamlLint::Lint.new(filename, lines[index], descriptions[index],
+                             severities[index])
+        end
+      end
+
+      subject { HamlLint::CLI.new }
+
+      it 'sorts nil line without blowing up' do
+        subject.send(:report_lints, lints).should_not raise_exception
+      end
+    end
+  end
 end


### PR DESCRIPTION
A sorting exception occurs when sorting two lints on one file where one lint has
line number 'nil' and the other one not. This commit fixes the issue by
treating 'nil' line numbers as 0.
