### PR TITLE
Fix names of excluded RuboCop cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix crash when reporting a lint from Rubocop that did not include a line
   number
+* Fix names of excluded RuboCop cops
 
 ## 0.5.2
 

--- a/lib/haml_lint/linter/ruby_script.rb
+++ b/lib/haml_lint/linter/ruby_script.rb
@@ -48,17 +48,17 @@ module HamlLint
     # These cops are incredibly noisy with Ruby code extracted from HAML,
     # and are safe to ignore
     IGNORED_COPS = %w[
-      BlockAlignment
-      BlockNesting
-      EndAlignment
-      FileName
-      IfUnlessModifier
-      IndentationWidth
-      LineLength
-      Next
-      TrailingWhitespace
-      Void
-      WhileUntilModifier
+      Lint/BlockAlignment
+      Lint/EndAlignment
+      Lint/Void
+      Style/BlockNesting
+      Style/FileName
+      Style/IfUnlessModifier
+      Style/IndentationWidth
+      Style/LineLength
+      Style/Next
+      Style/TrailingWhitespace
+      Style/WhileUntilModifier
     ]
 
     def extract_lints_from_offences(offences)

--- a/spec/linter/ruby_script_spec.rb
+++ b/spec/linter/ruby_script_spec.rb
@@ -33,7 +33,7 @@ describe HamlLint::Linter::RubyScript do
     end
 
     context 'and the offence is from an ignored cop' do
-      let(:cop_name) { 'LineLength' }
+      let(:cop_name) { described_class::IGNORED_COPS.first }
       it { should_not report_lint }
     end
   end


### PR DESCRIPTION
The names are now prefixed with the namespace.

It would be great to have a new version including this fix.
