### PR TITLE
fix linter base helper methods to check for nil input

### DIFF
--- a/lib/haml_lint/linter.rb
+++ b/lib/haml_lint/linter.rb
@@ -47,6 +47,7 @@ module HamlLint
     # @param string [String]
     # @return [true,false]
     def contains_interpolation?(string)
+      return false unless string
       Haml::Util.contains_interpolation?(string)
     end
 
@@ -57,8 +58,7 @@ module HamlLint
     # @return [true,false]
     def tag_has_inline_script?(tag_node)
       tag_with_inline_content = tag_with_inline_text(tag_node)
-      inline_content = inline_node_content(tag_node)
-
+      return false unless inline_content = inline_node_content(tag_node)
       return false unless index = tag_with_inline_content.rindex(inline_content)
 
       index -= 1

--- a/spec/haml_lint/linter/unnecessary_string_output_spec.rb
+++ b/spec/haml_lint/linter/unnecessary_string_output_spec.rb
@@ -3,6 +3,14 @@ require 'spec_helper'
 describe HamlLint::Linter::UnnecessaryStringOutput do
   include_context 'linter'
 
+  context 'when tag contains no inline text' do
+    let(:haml) { <<-HAML }
+      %tag
+       Some non-inline text
+    HAML
+    it { should_not report_lint }
+  end
+
   context 'when tag contains inline text without interpolation' do
     let(:haml) { '%tag Some inline text' }
     it { should_not report_lint }


### PR DESCRIPTION
This fixes a bug in linter.rb which is exposed in Linter::UnnecessaryStringOutput where certain helper methods assumed non-nil input.
