### PR TITLE
better support for templates with frontmatter

### DIFF
--- a/lib/haml_lint/configuration.rb
+++ b/lib/haml_lint/configuration.rb
@@ -1,6 +1,8 @@
 module HamlLint
   # Stores configuration for haml-lint.
   class Configuration
+    attr_reader :hash
+
     # Creates a configuration from the given options hash.
     #
     # @param options [Hash]
@@ -51,10 +53,6 @@ module HamlLint
     def merge(config)
       self.class.new(smart_merge(@hash, config.hash))
     end
-
-  protected
-
-    attr_reader :hash
 
   private
 

--- a/lib/haml_lint/parser.rb
+++ b/lib/haml_lint/parser.rb
@@ -5,12 +5,28 @@ module HamlLint
   class Parser
     attr_reader :contents, :filename, :lines, :tree
 
-    def initialize(haml_or_filename)
+    def initialize(haml_or_filename, options = {})
       if File.exist?(haml_or_filename)
         @filename = haml_or_filename
         @contents = File.read(haml_or_filename)
       else
         @contents = haml_or_filename
+      end
+
+      if options['skip_frontmatter'] &&
+        @contents =~ /
+          # from the start of the string
+          \A
+          # first-capture match --- followed by optional whitespace up
+          # to a newline then 0 or more chars followed by an optional newline.
+          # this matches the --- and the contents of the frontmatter
+          (---\s*\n.*?\n?)
+          # from the start of the line
+          ^
+          # second capture match --- or ... followed by optional whitespace
+          # and newline. This matches the closing --- for the frontmatter.
+          (---|\.\.\.)\s*$\n?/mx
+        @contents = $POSTMATCH
       end
 
       @lines = @contents.split("\n")

--- a/lib/haml_lint/runner.rb
+++ b/lib/haml_lint/runner.rb
@@ -16,7 +16,7 @@ module HamlLint
 
       @lints = []
       files.each do |file|
-        find_lints(file, linters)
+        find_lints(file, linters, config)
       end
 
       linters.each do |linter|
@@ -53,8 +53,8 @@ module HamlLint
       end.compact
     end
 
-    def find_lints(file, linters)
-      parser = Parser.new(file)
+    def find_lints(file, linters, config)
+      parser = Parser.new(file, config.hash)
 
       linters.each do |linter|
         linter.run(parser)

--- a/spec/haml_lint/parser_spec.rb
+++ b/spec/haml_lint/parser_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe HamlLint::Parser do
+  context 'when skip_frontmatter is true' do
+    let(:parser) { HamlLint::Parser.new(haml, 'skip_frontmatter' => true) }
+
+    let(:haml) { <<-HAML }
+---
+:key: value
+---
+%tag
+  Some non-inline text
+- 'some code'
+    HAML
+
+    it 'excludes the frontmatter' do
+      expect(parser.contents).to eq(<<-CONTENT)
+%tag
+  Some non-inline text
+- 'some code'
+      CONTENT
+    end
+
+    context 'when haml has --- as content' do
+      let(:haml) { <<-HAML }
+---
+:key: value
+---
+%tag
+  Some non-inline text
+- 'some code'
+  ---
+    HAML
+
+      it 'is not greedy' do
+        expect(parser.contents).to eq(<<-CONTENT)
+%tag
+  Some non-inline text
+- 'some code'
+  ---
+      CONTENT
+      end
+    end
+  end
+
+  context 'when skip_frontmatter is false' do
+    let(:parser) { HamlLint::Parser.new(haml, 'skip_frontmatter' => false) }
+    let(:haml) { <<-HAML }
+---
+:key: value
+---
+%tag
+  Some non-inline text
+- 'some code'
+    HAML
+
+    it 'raises HAML error' do
+      expect { parser }.to raise_error('Invalid filter name ":key: value".')
+    end
+  end
+end


### PR DESCRIPTION
This adds support for excluding frontmatter settings common in many static site generators like Middleman and Jekyll. I didn't see equivalent of RuboCop's AllCops config setting, so I added a global option. I'm open to renaming it AllLinters if we want to follow RC's lead. The frontmatter support is controlled by a new global config option 'skip-frontmatter', which defaults to false so it's opt-in and shouldn't break anyone.
