### PR TITLE
Fixing link in linter README

### DIFF
--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -290,7 +290,7 @@ example.haml:3 [W] Useless assignment to variable - unused_variable
 ```
 
 You can customize which RuboCop warnings you want to ignore by modifying
-the `ignored_cops` option (see [`config/default.yml`](config/default.yml)
+the `ignored_cops` option (see [`config/default.yml`](/config/default.yml)
 for the full list of ignored cops).
 
 ## RubyComments


### PR DESCRIPTION
The link was a relative path, and would go to `/lib/haml_lint/linter/config/default.yml`, which doesn't exist.
