### PR TITLE
Fix rake task

### DIFF
--- a/lib/haml_lint/rake_task.rb
+++ b/lib/haml_lint/rake_task.rb
@@ -59,7 +59,8 @@ module HamlLint
       require 'haml_lint/cli'
 
       logger = HamlLint::Logger.new(STDOUT)
-      exit HamlLint::CLI.new(logger).run(cli_args)
+      result = HamlLint::CLI.new(logger).run(cli_args)
+      abort('HamlLint failed') unless result == 0
     end
   end
 end


### PR DESCRIPTION
Do not exit by default
Abort on error only.
