### PR TITLE
Don't fail on empty comment lines

### DIFF
--- a/lib/haml_lint/linter/leading_comment_space.rb
+++ b/lib/haml_lint/linter/leading_comment_space.rb
@@ -4,7 +4,7 @@ module HamlLint
     include LinterRegistry
 
     def visit_haml_comment(node)
-      return if node.text[0] == ' '
+      return if node.text.empty? || node.text[0] == ' '
 
       add_lint(node, 'Comment should have a space after the `#`')
     end

--- a/spec/haml_lint/linter/leading_comment_space_spec.rb
+++ b/spec/haml_lint/linter/leading_comment_space_spec.rb
@@ -14,4 +14,10 @@ describe HamlLint::Linter::LeadingCommentSpace do
 
     it { should report_lint }
   end
+
+  context 'when a comment is on an empty line with no leading space' do
+    let(:haml) { '-#' }
+
+    it { should_not report_lint }
+  end
 end


### PR DESCRIPTION
If you comment out multiple lines in haml, there are often empty lines which just have the '-#' for the comment. The TrailingWhitespace linter does not allow a space at the end of the line but the LeadingCommentSpace linter requires it.

This commit fixes the LeadingCommentSpace linter by allowing a comment without a leading whitespace if the comment is empty.
