### PR TITLE
include hash source for hashrocket hash attributes

### DIFF
--- a/lib/haml_lint/script_extractor.rb
+++ b/lib/haml_lint/script_extractor.rb
@@ -117,7 +117,7 @@ module HamlLint
       # https://github.com/haml/haml/blob/08f97ec4dc8f59fe3d7f6ab8f8807f86f2a15b68/lib/haml/parser.rb#L540-L554
       # Here, we add the hash source back in so it can be inspected by rubocop.
       if node.hash_attributes? && node.dynamic_attributes_sources.empty?
-        add_line("#{node.dynamic_attributes_source[:hash]}.merge(Hash.new(0))", node)
+        add_line(node.dynamic_attributes_source[:hash], node)
       end
     end
 

--- a/spec/haml_lint/script_extractor_spec.rb
+++ b/spec/haml_lint/script_extractor_spec.rb
@@ -106,7 +106,7 @@ describe HamlLint::ScriptExtractor do
       HAML
 
       it 'includes the hash attribute source for rubocop inspection' do
-        should == "{:type=>'checkbox', 'special' => :true }.merge(Hash.new(0))\nputs # tag"
+        should == "{:type=>'checkbox', 'special' => :true }\nputs # tag"
       end
     end
 


### PR DESCRIPTION
Fix an issue where, if a tag has hash attributes consisting only of of strings and symbols and is written in hashrocket style, those attributes were not present in the extracted script source passed to rubocop, and so were going unchecked.
