### PR TITLE
Haml hash attributes spacing linter

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -69,10 +69,7 @@ linters:
 
   SpaceInsideHashAttributes:
     enabled: true
-    EnforcedStyle: space
-    SupportedStyles:
-      - space
-      - no_space
+    style: space
 
   TagName:
     enabled: true

--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -354,12 +354,14 @@ styles, `space` (default) or `no_space`:
 %tag{  foo: bar }
 ```
 
-**Space: require a single space inside hash attributes braces**
+**With default `space` style option: require a single space inside
+hash attributes braces**
 ```haml
 %tag{ foo: bar }
 ```
 
-**No Space: require no space inside hash attributes braces**
+**With `no_space` style option: require no space inside
+hash attributes braces**
 ```haml
 %tag{foo: bar}
 ```

--- a/lib/haml_lint/linter/space_inside_hash_attributes.rb
+++ b/lib/haml_lint/linter/space_inside_hash_attributes.rb
@@ -22,7 +22,7 @@ module HamlLint
     def visit_tag(node)
       return unless node.hash_attributes?
 
-      style = STYLE[config['EnforcedStyle'] == 'no_space' ? 'no_space' : 'space']
+      style = STYLE[config['style'] == 'no_space' ? 'no_space' : 'space']
       source = node.hash_attributes_source
 
       add_lint(node, style[:start_message]) unless source =~ style[:start_regex]

--- a/spec/haml_lint/linter/space_inside_hash_attributes_spec.rb
+++ b/spec/haml_lint/linter/space_inside_hash_attributes_spec.rb
@@ -9,8 +9,9 @@ describe HamlLint::Linter::SpaceInsideHashAttributes do
     context 'default config (space)' do
       it { should_not report_lint }
     end
+
     context 'with no_space config' do
-      let(:config) { super().merge('EnforcedStyle' => 'no_space') }
+      let(:config) { super().merge('style' => 'no_space') }
       it { should_not report_lint }
     end
   end
@@ -21,8 +22,9 @@ describe HamlLint::Linter::SpaceInsideHashAttributes do
     context 'default config (space)' do
       it { should_not report_lint }
     end
+
     context 'with no_space config' do
-      let(:config) { super().merge('EnforcedStyle' => 'no_space') }
+      let(:config) { super().merge('style' => 'no_space') }
       it { should report_lint }
     end
   end
@@ -33,8 +35,9 @@ describe HamlLint::Linter::SpaceInsideHashAttributes do
     context 'default config (space)' do
       it { should report_lint }
     end
+
     context 'with no_space config' do
-      let(:config) { super().merge('EnforcedStyle' => 'no_space') }
+      let(:config) { super().merge('style' => 'no_space') }
       it { should_not report_lint }
     end
   end
@@ -45,8 +48,9 @@ describe HamlLint::Linter::SpaceInsideHashAttributes do
     context 'default config (space)' do
       it { should report_lint }
     end
+
     context 'with no_space config' do
-      let(:config) { super().merge('EnforcedStyle' => 'no_space') }
+      let(:config) { super().merge('style' => 'no_space') }
       it { should report_lint }
     end
   end
@@ -57,8 +61,9 @@ describe HamlLint::Linter::SpaceInsideHashAttributes do
     context 'default config (space)' do
       it { should report_lint }
     end
+
     context 'with no_space config' do
-      let(:config) { super().merge('EnforcedStyle' => 'no_space') }
+      let(:config) { super().merge('style' => 'no_space') }
       it { should report_lint }
     end
   end
@@ -69,8 +74,9 @@ describe HamlLint::Linter::SpaceInsideHashAttributes do
     context 'default config (space)' do
       it { should report_lint }
     end
+
     context 'with no_space config' do
-      let(:config) { super().merge('EnforcedStyle' => 'no_space') }
+      let(:config) { super().merge('style' => 'no_space') }
       it { should report_lint }
     end
   end
@@ -81,10 +87,10 @@ describe HamlLint::Linter::SpaceInsideHashAttributes do
     context 'default config (space)' do
       it { should report_lint }
     end
+
     context 'with no_space config' do
-      let(:config) { super().merge('EnforcedStyle' => 'no_space') }
+      let(:config) { super().merge('style' => 'no_space') }
       it { should report_lint }
     end
   end
-
 end


### PR DESCRIPTION
Add a linter for checking for spaces inside hash attribute braces, analogous to the Style/SpaceInsideHashLiteralBraces cop for spaces inside ruby hash literal braces.
