### PR TITLE
fix TagNode#dynamic_attributes_source for implicit div tags

### DIFF
--- a/lib/haml_lint/tree/tag_node.rb
+++ b/lib/haml_lint/tree/tag_node.rb
@@ -70,7 +70,7 @@ module HamlLint::Tree
       @dynamic_attributes_source ||=
         begin
           _tag_name, _static_attrs, rest = source_code
-            .scan(/%([-:\w]+)([-:\w\.\#]*)(.*)/m)[0]
+            .scan(/(?:%|\A\s*\.)([-:\w]+)([-:\w\.\#]*)(.*)/m)[0]
 
           attr_types = {
             '{' => [:hash, %w[{ }]],

--- a/spec/haml_lint/linter/space_inside_hash_attributes_spec.rb
+++ b/spec/haml_lint/linter/space_inside_hash_attributes_spec.rb
@@ -42,6 +42,19 @@ describe HamlLint::Linter::SpaceInsideHashAttributes do
     end
   end
 
+  context 'when an implicit-div tag contains hash attributes without leading or trailing spaces' do
+    let(:haml) { ".some_class{lang: 'en'}" }
+
+    context 'default config (space)' do
+      it { should report_lint }
+    end
+
+    context 'with no_space config' do
+      let(:config) { super().merge('style' => 'no_space') }
+      it { should_not report_lint }
+    end
+  end
+
   context 'when a tag contains hash attributes without a leading space but with a trailing space' do
     let(:haml) { "%tag{lang: 'en' }" }
 

--- a/spec/haml_lint/tree/tag_node_spec.rb
+++ b/spec/haml_lint/tree/tag_node_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe HamlLint::Tree::TagNode do
   let(:parser) { HamlLint::Parser.new(normalize_indent(haml)) }
-  let(:tag_node) { parser.tree.find { |node| node.type == :tag && node.tag_name == 'my_tag' } }
+  let(:tag_node) { parser.tree.find { |node| node.type == :tag && node.tag_name == tag_name } }
+  let(:tag_name) { 'my_tag' }
 
   describe '#dynamic_attributes_source' do
     subject { tag_node.dynamic_attributes_source }
@@ -38,6 +39,22 @@ describe HamlLint::Tree::TagNode do
       let(:haml) { '%my_tag.class_one.class_two#with_an_id{ one: 1, two: 2 }' }
 
       it { should == { hash: '{ one: 1, two: 2 }' } }
+    end
+
+    context 'with hash attributes on an implicit div' do
+      let(:tag_name) { 'div' }
+
+      context 'at the beginning of a line' do
+        let(:haml) { '.class_one.class_two#with_an_id{ one: 1, two: 2 }' }
+
+        it { should == { hash: '{ one: 1, two: 2 }' } }
+      end
+
+      context 'with leading whitespace' do
+        let(:haml) { '  .class_one.class_two#with_an_id{ one: 1, two: 2 }' }
+
+        it { should == { hash: '{ one: 1, two: 2 }' } }
+      end
     end
 
     context 'with multi-line hash attributes' do


### PR DESCRIPTION
Fix the regular expression in `TagNode#dynamic_attributes_source`, which was only matching explicit tags like `%my_tag`, to also extract attributes from implicit div tags (like `.some_class{ foo: 'bar' }`) for inspection.
