### PR TITLE
Syntax linter should catch malformed HTML attributes

### DIFF
--- a/spec/haml_lint/linter/syntax_spec.rb
+++ b/spec/haml_lint/linter/syntax_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe HamlLint::Linter::Syntax do
+  let(:base_options) { { reporter: reporter } }
+  let(:options) { base_options }
+  let(:reporter) { HamlLint::Reporter::HashReporter.new(StringIO.new) }
+  let(:runner) { HamlLint::Runner.new }
+  let(:filename) { 'syntax_text.haml' }
+
+  include_context 'isolated environment'
+
+  before do
+    `echo "#{haml}" > #{filename}`
+    runner.stub(:extract_applicable_files).and_return([filename])
+  end
+
+  subject { runner.run(options) }
+
+  context 'when RuboCop linter is disabled' do
+    let(:options) { base_options.merge excluded_linters: %w(RuboCop) }
+
+    context 'when syntax is valid' do
+      let(:haml) { '%tag{ a: "A", b: "B" }' }
+
+      it 'adds a syntax lint to the output' do
+        subject.lints.size.should == 0
+      end
+    end
+
+    # context 'when there are invalid hash attributes' do
+    #   let(:haml) { '%tag{ a: "A" b: "B" }' }
+    #
+    #   it { should report_syntax_lint }
+    #   it { should report_on_line 2 }
+    #   it { should report_message /unexpected token/ }
+    #   it { should report_severity :error }
+    # end
+
+    context 'when there is an indentation syntax error' do
+      let(:haml) { "%div\n  %span Hello, world\n\t%span Goodnight, moon" }
+
+      it { should report_syntax_lint }
+      it { should report_on_line 2 }
+      it { should report_message /^Inconsistent indentation/ }
+      it { should report_severity :error }
+    end
+  end
+end
+
+RSpec::Matchers.define :report_syntax_lint do
+  match do |report|
+    report.lints.size == 1 && report.lints.first.linter.name == 'Syntax'
+  end
+end
+
+RSpec::Matchers.define :report_on_line do |expected_line_number|
+  match do |report|
+    report.lints.size == 1 && expected_line_number == report.lints.first.line
+  end
+end
+
+RSpec::Matchers.define :report_message do |expected_message|
+  match do |report|
+    report.lints.size == 1 && expected_message === report.lints.first.message
+  end
+end
+
+RSpec::Matchers.define :report_severity do |expected_severity|
+  match do |report|
+    report.lints.size == 1 && report.lints.first.severity == expected_severity
+  end
+end

--- a/spec/haml_lint/linter/syntax_spec.rb
+++ b/spec/haml_lint/linter/syntax_spec.rb
@@ -30,19 +30,23 @@ describe HamlLint::Linter::Syntax do
     context 'when there are invalid hash attributes' do
       let(:haml) { '%tag{ a: "A" b: "B" }' }
 
-      it { should report_syntax_lint }
-      it { should report_on_line 2 }
-      it { should report_message /unexpected token/ }
-      it { should report_severity :error }
+      it do
+        should report_syntax_lint
+        should report_on_line 2
+        should report_message /unexpected token/
+        should report_severity :error
+      end
     end
 
     context 'when there is an indentation syntax error' do
       let(:haml) { "%div\n  %span Hello, world\n\t%span Goodnight, moon" }
 
-      it { should report_syntax_lint }
-      it { should report_on_line 2 }
-      it { should report_message /^Inconsistent indentation/ }
-      it { should report_severity :error }
+      it do
+        should report_syntax_lint
+        should report_on_line 2
+        should report_message /^Inconsistent indentation/
+        should report_severity :error
+      end
     end
   end
 end

--- a/spec/haml_lint/linter/syntax_spec.rb
+++ b/spec/haml_lint/linter/syntax_spec.rb
@@ -27,14 +27,14 @@ describe HamlLint::Linter::Syntax do
       end
     end
 
-    # context 'when there are invalid hash attributes' do
-    #   let(:haml) { '%tag{ a: "A" b: "B" }' }
-    #
-    #   it { should report_syntax_lint }
-    #   it { should report_on_line 2 }
-    #   it { should report_message /unexpected token/ }
-    #   it { should report_severity :error }
-    # end
+    context 'when there are invalid hash attributes' do
+      let(:haml) { '%tag{ a: "A" b: "B" }' }
+
+      it { should report_syntax_lint }
+      it { should report_on_line 2 }
+      it { should report_message /unexpected token/ }
+      it { should report_severity :error }
+    end
 
     context 'when there is an indentation syntax error' do
       let(:haml) { "%div\n  %span Hello, world\n\t%span Goodnight, moon" }

--- a/spec/haml_lint/runner_spec.rb
+++ b/spec/haml_lint/runner_spec.rb
@@ -61,33 +61,6 @@ describe HamlLint::Runner do
           subject
         end
       end
-
-      context 'when there is a Haml parsing error in a file' do
-        let(:files) { %w[inconsistent_indentation.haml] }
-
-        include_context 'isolated environment'
-
-        before do
-          # The runner needs to actually look for files to lint
-          runner.should_receive(:collect_lints).and_call_original
-          haml = "%div\n  %span Hello, world\n\t%span Goodnight, moon"
-
-          `echo "#{haml}" > inconsistent_indentation.haml`
-        end
-
-        it 'adds a syntax lint to the output' do
-          subject.lints.size.should == 1
-
-          lint = subject.lints.first
-          lint.line.should == 2
-          lint.filename.should == 'inconsistent_indentation.haml'
-          lint.message.should match(/^Inconsistent indentation/)
-          lint.severity.should == :error
-
-          linter = lint.linter
-          linter.name.should == 'Syntax'
-        end
-      end
     end
 
     context 'integration tests' do


### PR DESCRIPTION
I'd like haml-lint's Syntax linter to catch syntax errors in HAML files, even if the RuboCop linter is disabled.

> Note: So far I've only got a failing test.  I haven't sufficiently wrapped my head around this project to spot the idiomatic way to detect malformed HAML, and would appreciate guidance with the actual fix!  Also please let me know if this test belongs in a different spec.

## Syntax error I'd like to catch
```
> echo "%tag{a: 'A',  b: 'B'}" | haml -s
<tag a='A' b='B'></tag>

> echo "%tag{a: 'A'  b: 'B'}" | haml -s
Syntax error on line 128: (haml):1: syntax error, unexpected tIDENTIFIER, expecting ')'
...ut.attributes({}, nil,a: 'A'  b: 'B')).to_s);; _hamlout.buff...
...                              ^
  Use --trace for backtrace.
```


## Context
Our project uses haml-lint but has the RuboCop linter disabled.

[Yesterday I committed and merged a HAML syntax error](https://github.com/code-dot-org/code-dot-org/pull/23195#issuecomment-398893034) on one of my projects that I expected the linter to catch.

I've got haml-lint in a precommit hook, that surfaced this linter error:

```
HtmlAttributes: Prefer the hash attributes syntax (%tag{ lang: 'en' }) over
  HTML attributes syntax (%tag(lang=en))
```

In a hasty fix, I converted
```haml
%a(href="..." target='_blank')
```
to
```haml
%a{href: "..." target='_blank'}
```
and committed the change without testing it.  This time the linter didn't complain, which I find  disappointing since it's now _completely_ broken instead of just using the wrong valid syntax.

## Changes
Moves the one Syntax linter test into its own file, and introduces a new failing test for the case I've described.