### PR TITLE
Allow using auto-gen-config with a custom configuration file

### DIFF
--- a/lib/haml_lint/configuration_loader.rb
+++ b/lib/haml_lint/configuration_loader.rb
@@ -13,15 +13,20 @@ module HamlLint
     class << self
       # Load configuration file given the current working directory the
       # application is running within.
-      def load_applicable_config
-        directory = File.expand_path(Dir.pwd)
-        config_file = possible_config_files(directory).find(&:file?)
-
+      def load_applicable_config(config_file = nil)
+        config_file ||= default_path_to_config
         if config_file
-          load_file(config_file.to_path)
+          load_file(config_file)
         else
           default_configuration
         end
+      end
+
+      # Path to the default config file, if it exists
+      def default_path_to_config
+        directory = File.expand_path(Dir.pwd)
+        config_file = possible_config_files(directory).find(&:file?)
+        config_file ? config_file.to_path : nil
       end
 
       # Loads the built-in default configuration.

--- a/lib/haml_lint/runner.rb
+++ b/lib/haml_lint/runner.rb
@@ -59,12 +59,10 @@ module HamlLint
     def load_applicable_config(options)
       if options[:auto_gen_config]
         HamlLint::ConfigurationLoader.default_configuration
-      elsif options[:config_file]
-        HamlLint::ConfigurationLoader.load_file(options[:config_file])
       elsif options[:config]
         options[:config]
       else
-        HamlLint::ConfigurationLoader.load_applicable_config
+        HamlLint::ConfigurationLoader.load_applicable_config(options[:config_file])
       end
     end
 

--- a/lib/haml_lint/runner.rb
+++ b/lib/haml_lint/runner.rb
@@ -57,10 +57,13 @@ module HamlLint
     # @param options [Hash]
     # @return [HamlLint::Configuration]
     def load_applicable_config(options)
-      if options[:auto_gen_config]
-        HamlLint::ConfigurationLoader.default_configuration
-      elsif options[:config]
+      if options[:config]
         options[:config]
+      elsif options[:auto_gen_config]
+        HamlLint::ConfigurationLoader.load_applicable_config(
+          options[:config_file],
+          exclude_files: [HamlLint::ConfigurationLoader::AUTO_GENERATED_FILE]
+        )
       else
         HamlLint::ConfigurationLoader.load_applicable_config(options[:config_file])
       end

--- a/spec/haml_lint/configuration_loader_spec.rb
+++ b/spec/haml_lint/configuration_loader_spec.rb
@@ -28,7 +28,7 @@ describe HamlLint::ConfigurationLoader do
 
       it 'loads the file' do
         described_class.should_receive(:load_file)
-                       .with(File.expand_path('.haml-lint.yml'))
+                       .with(File.expand_path('.haml-lint.yml'), {})
         subject
       end
 
@@ -192,6 +192,13 @@ describe HamlLint::ConfigurationLoader do
 
             subject.should ==
               described_class.default_configuration.merge(custom_config)
+          end
+        end
+
+        context 'when the inherited file is excluded' do
+          subject { described_class.load_file(file_name, exclude_files: [other_config]) }
+          it 'ignores the inherited file' do
+            subject['linters']['Indentation']['enabled'].should == true
           end
         end
 

--- a/spec/haml_lint/runner_spec.rb
+++ b/spec/haml_lint/runner_spec.rb
@@ -35,9 +35,24 @@ describe HamlLint::Runner do
         it 'loads that specified configuration file' do
           config.stub(:for_linter).and_return('enabled' => true)
 
-          HamlLint::ConfigurationLoader.should_receive(:load_file)
+          HamlLint::ConfigurationLoader.should_receive(:load_applicable_config)
                                        .with('some-config.yml')
                                        .and_return(config)
+          subject
+        end
+      end
+
+      context 'when :auto_gen_config option is specified' do
+        let(:options) { base_options.merge(auto_gen_config: true) }
+        let(:config) { double('config') }
+
+        it 'loads that specified configuration file' do
+          config.stub(:for_linter).and_return('enabled' => true)
+
+          HamlLint::ConfigurationLoader.should_receive(:load_applicable_config)
+                                       .with(nil, exclude_files: [
+                                               HamlLint::ConfigurationLoader::AUTO_GENERATED_FILE
+                                             ]).and_return(config)
           subject
         end
       end


### PR DESCRIPTION
At the moment it's not possible to use auto-gen-config with disabled or customized rules in .haml-lint.yml, since Runner just loads the default configuration.

What about this change?  By default it'll fall through to `HamlLint::ConfigurationLoader.load_applicable_config`, which will attempt to load .haml-lint.yml if it exists, and the default configuration if not.