### PR TITLE
Add a reproduction test for #303

### DIFF
--- a/spec/haml_lint/linter/line_length_spec.rb
+++ b/spec/haml_lint/linter/line_length_spec.rb
@@ -62,4 +62,15 @@ describe HamlLint::Linter::LineLength do
     it { should_not report_lint line: 3 }
     it { should report_lint line: 5 }
   end
+
+  context 'when there is a directive on the line before a long line' do
+    let(:haml) do
+      <<-HAML
+        -# haml-lint:disable LineLength
+        %table.responsive.table.table-sm.table-striped.table-bordered.w-100#excluded-requests-datatable{ data: 'excluded_requests_remote_url(@staging_workflow.id)' }
+      HAML
+    end
+
+    it { should_not report_lint }
+  end
 end


### PR DESCRIPTION
This is the reported format of line that fails on the LineLength linter.
As such, the line should fail in isolation but it doesn't fail in the
test suite. I'm going to push this up for review and solicit more
feedback from the reporters.