### PR TITLE
Ignor Layout/CaseIndentation cop by default

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -93,6 +93,7 @@ linters:
       - Lint/Void
       - Layout/AlignHash
       - Layout/AlignParameters
+      - Layout/CaseIndentation
       - Layout/ElseAlignment
       - Layout/EndOfLine
       - Layout/IndentationWidth


### PR DESCRIPTION
In Rubocop we have following settings:
Layout/CaseIndentation:
  EnforcedStyle: case
  IndentOneStep: true

In haml we have:
```
                - case item
                  - when 'home'
                    = link_to item, '#header'
```
It is a correct haml and in fact indented as required, but haml_lint produces:
RuboCop: Layout/CaseIndentation: Indent `when` one step more than `case`.

So I propose to disable this cop in default configuration

