### PR TITLE
Update README with correct `auto-gen-exclude-limit` syntax and add flags to table

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,22 +71,24 @@ filename and line number.
 
 ### Command Line Flags
 
-Command Line Flag         | Description
---------------------------|----------------------------------------------------
-`-c`/`--config`           | Specify which configuration file to use
-`-e`/`--exclude`          | Exclude one or more files from being linted
-`-i`/`--include-linter`   | Specify which linters you specifically want to run
-`-x`/`--exclude-linter`   | Specify which linters you _don't_ want to run
-`-r`/`--reporter`         | Specify which reporter you want to use to generate the output
-`--fail-fast`             | Specify whether to fail after the first file with lint
-`--fail-level`            | Specify the minimum severity (warning or error) for which the lint should fail
-`--[no-]color`            | Whether to output in color
-`--[no-]summary`          | Whether to output a summary in the default reporter
-`--show-linters`          | Show all registered linters
-`--show-reporters`        | Display available reporters
-`-h`/`--help`             | Show command line flag documentation
-`-v`/`--version`          | Show `haml-lint` version
-`-V`/`--verbose-version`  | Show `haml-lint`, `haml`, and `ruby` version information
+Command Line Flag          | Description
+---------------------------|----------------------------------------------------
+`--auto-gen-config`        | Generate a configuration file acting as a TODO list
+`--auto-gen-exclude-limit` | Number of failures to allow in the TODO list before the entire rule is excluded
+`-c`/`--config`            | Specify which configuration file to use
+`-e`/`--exclude`           | Exclude one or more files from being linted
+`-i`/`--include-linter`    | Specify which linters you specifically want to run
+`-x`/`--exclude-linter`    | Specify which linters you _don't_ want to run
+`-r`/`--reporter`          | Specify which reporter you want to use to generate the output
+`--fail-fast`              | Specify whether to fail after the first file with lint
+`--fail-level`             | Specify the minimum severity (warning or error) for which the lint should fail
+`--[no-]color`             | Whether to output in color
+`--[no-]summary`           | Whether to output a summary in the default reporter
+`--show-linters`           | Show all registered linters
+`--show-reporters`         | Display available reporters
+`-h`/`--help`              | Show command line flag documentation
+`-v`/`--version`           | Show `haml-lint` version
+`-V`/`--verbose-version`   | Show `haml-lint`, `haml`, and `ruby` version information
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -295,9 +295,9 @@ as exclusions. You can then add `inherits_from: .haml-lint_todo.yml` to your
 you call `haml-lint`.
 
 By default, any rules with more than 15 violations will be disabled in the todo-file.
-You can increase this limit with the `exclude-limit` option:
+You can increase this limit with the `auto-gen-exclude-limit` option:
 
-    haml-lint --auto-gen-config --exclude-limit 100
+    haml-lint --auto-gen-config --auto-gen-exclude-limit 100
 
 
 ## Editor Integration


### PR DESCRIPTION
This updates usages of the `exclude-limit` option to correctly be `auto-gen-exclude-limit`, and also adds the `auto-gen`-related command line options to the table.