### PR TITLE
Fix a bug that disabling directives are not properly applied in some cases

### DIFF
--- a/lib/haml_lint/tree/node.rb
+++ b/lib/haml_lint/tree/node.rb
@@ -105,7 +105,7 @@ module HamlLint::Tree
       return (line..line) unless @value && text
 
       end_line = line + lines.count
-      end_line = nontrivial_end_line if line == end_line
+      end_line = nontrivial_end_line if line == end_line && children.empty?
 
       (line..end_line)
     end
@@ -161,9 +161,7 @@ module HamlLint::Tree
     #
     # @return [Integer] the end line of the node
     def nontrivial_end_line
-      if (last_child = children.last)
-        last_child.line_numbers.end - 1
-      elsif successor
+      if successor
         successor.line_numbers.begin - 1
       else
         @document.source_lines.count

--- a/spec/haml_lint/linter/line_length_spec.rb
+++ b/spec/haml_lint/linter/line_length_spec.rb
@@ -62,4 +62,17 @@ describe HamlLint::Linter::LineLength do
     it { should_not report_lint line: 3 }
     it { should report_lint line: 5 }
   end
+
+  context 'when there is a directive on the line before a long line' do
+    let(:haml) do
+      <<-HAML
+        #test
+          -# haml-lint:disable LineLength
+          %table.responsive.table.table-sm.table-striped.table-bordered.w-100#excluded-requests-datatable{ data: 'excluded_requests_remote_url(@staging_workflow.id)' }
+          %br
+      HAML
+    end
+
+    it { should_not report_lint }
+  end
 end

--- a/spec/haml_lint/tree/node_spec.rb
+++ b/spec/haml_lint/tree/node_spec.rb
@@ -163,7 +163,7 @@ describe HamlLint::Tree::Node do
         HAML
       end
 
-      it { should == (1..3) }
+      it { should == (1..1) }
 
       context 'with a successor' do
         let(:haml) do
@@ -175,7 +175,7 @@ describe HamlLint::Tree::Node do
           HAML
         end
 
-        it { should == (1..3) }
+        it { should == (1..1) }
       end
     end
 


### PR DESCRIPTION
This PR fixes #303 

Node#line_numbers includes line numbers of child nodes. That causes RootNode#node_for_line to return an ancestor of the node containing the specified line.

Directives are applied based on RootNode#node_for_line, so there are cases like #303 where directives are not properly applied.

#### Concerns

This PR reverts some part of #278, which is about multiline node handling.
I believe child nodes are not meant to be handled like multilines, and this PR should be okay.