### PR TITLE
Allow rake 13

### DIFF
--- a/haml_lint.gemspec
+++ b/haml_lint.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'haml', '>= 4.0', '< 5.2'
   s.add_dependency 'rainbow'
-  s.add_dependency 'rake', '>= 10', '< 13'
+  s.add_dependency 'rake', '>= 10', '< 14'
   s.add_dependency 'rubocop', '>= 0.50.0'
   s.add_dependency 'sysexits', '~> 1.1'
 end


### PR DESCRIPTION
AFAICT, the only breaking change in rake 13 is dropping support for ruby < 2.2.