### PR TITLE
Fix problem with rubocop 0.77

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -91,13 +91,16 @@ linters:
       - Lint/BlockAlignment
       - Lint/EndAlignment
       - Lint/Void
-      - Layout/AlignHash
-      - Layout/AlignParameters
+      - Layout/AlignHash # renamed to Layout/HashAlignment in rubocop 0.77
+      - Layout/AlignParameters # renamed to Layout/ParameterAlignment in rubocop 0.77
       - Layout/CaseIndentation
       - Layout/ElseAlignment
       - Layout/EndOfLine
+      - Layout/HashAlignment
       - Layout/IndentationWidth
-      - Layout/TrailingBlankLines
+      - Layout/ParameterAlignment
+      - Layout/TrailingBlankLines # renamed to Layout/TrailingEmptyLines in rubocop 0.77
+      - Layout/TrailingEmptyLines
       - Layout/TrailingWhitespace
       - Metrics/BlockLength
       - Metrics/BlockNesting


### PR DESCRIPTION
haml-lint always fails when used with rubocop 0.77

rubocop 0.77 changed the name of Layout/TrailingBlankLines to Layout/TrailingEmptyLines.
haml-lint needs to ignore this cop, but it is not properly ignored with the latest rubocop due to the name change.