### PR TITLE
Update link to rubocop repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,7 @@
 ## 0.20.0
 
 * Update minimum RuboCop version to 0.47.0+ due to [breaking change in
-  RuboCop AST interface](https://github.com/bbatsov/rubocop/commit/48f1637eb36)
+  RuboCop AST interface](https://github.com/rubocop-hq/rubocop/commit/48f1637eb36)
 
 ## 0.19.0
 
@@ -405,6 +405,6 @@
 
 * New lint `SpaceBeforeScript` ensures that Ruby code in HAML indicated with the
   `-` and `=` characters always has one space separating them from code
-* New lint `RubyScript` integrates with [Rubocop](https://github.com/bbatsov/rubocop)
+* New lint `RubyScript` integrates with [Rubocop](https://github.com/rubocop-hq/rubocop)
   to report lints supported by that tool (respecting any existing `.rubocop.yml`
   configuration)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 `haml-lint` is a tool to help keep your [HAML](http://haml.info) files
 clean and readable. In addition to HAML-specific style and lint checks, it
-integrates with [RuboCop](https://github.com/bbatsov/rubocop) to bring its
+integrates with [RuboCop](https://github.com/rubocop-hq/rubocop) to bring its
 powerful static analysis tools to your HAML documents.
 
 You can run `haml-lint` manually from the command line, or integrate it into

--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -550,7 +550,7 @@ Option         | Description
 ---------------|--------------------------------------------
 `ignored_cops` | Array of RuboCop cops to ignore.
 
-This linter integrates with [RuboCop](https://github.com/bbatsov/rubocop)
+This linter integrates with [RuboCop](https://github.com/rubocop-hq/rubocop)
 (a static code analyzer and style enforcer) to check the actual Ruby code in
 your templates. It will respect any RuboCop-specific configuration you have
 set in `.rubocop.yml` files, but will explicitly ignore some checks that


### PR DESCRIPTION
RuboCop repository has been moved to rubocop-hq organization.
https://github.com/rubocop-hq/rubocop

So this pull-request updates old links with the new link.