### PR TITLE
Support --parallel option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Command Line Flag          | Description
 `-i`/`--include-linter`    | Specify which linters you specifically want to run
 `-x`/`--exclude-linter`    | Specify which linters you _don't_ want to run
 `-r`/`--reporter`          | Specify which reporter you want to use to generate the output
+`-p`/`--parallel`          | Run linters in parallel using available CPUs
 `--fail-fast`              | Specify whether to fail after the first file with lint
 `--fail-level`             | Specify the minimum severity (warning or error) for which the lint should fail
 `--[no-]color`             | Whether to output in color

--- a/haml_lint.gemspec
+++ b/haml_lint.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.4.0'
 
   s.add_dependency 'haml', '>= 4.0', '< 5.2'
+  s.add_dependency 'parallel', '~> 1.10'
   s.add_dependency 'rainbow'
   s.add_dependency 'rubocop', '>= 0.50.0'
   s.add_dependency 'sysexits', '~> 1.1'

--- a/lib/haml_lint/options.rb
+++ b/lib/haml_lint/options.rb
@@ -51,6 +51,10 @@ module HamlLint
                 "Specify which linters you don't want to run") do |linters|
         @options[:excluded_linters] = linters
       end
+
+      parser.on('-p', '--parallel', 'Run linters in parallel using available CPUs') do
+        @options[:parallel] = true
+      end
     end
 
     def add_report_options(parser)

--- a/spec/haml_lint/options_spec.rb
+++ b/spec/haml_lint/options_spec.rb
@@ -81,6 +81,14 @@ describe HamlLint::Options do
       end
     end
 
+    context 'with a parallel option' do
+      let(:args) { %w[--parallel] }
+
+      it 'sets the parallel option' do
+        subject[:parallel].should == true
+      end
+    end
+
     context 'fail fast' do
       let(:args) { %w[--fail-fast] }
 

--- a/spec/haml_lint/runner_spec.rb
+++ b/spec/haml_lint/runner_spec.rb
@@ -77,6 +77,15 @@ describe HamlLint::Runner do
         end
       end
 
+      context 'when :parallel option is specified' do
+        let(:options) { base_options.merge(files: files, parallel: true) }
+
+        it 'warms up the cache in parallel' do
+          runner.should_receive(:warm_cache).and_call_original
+          subject
+        end
+      end
+
       context 'when there is a Haml parsing error in a file' do
         let(:files) { %w[inconsistent_indentation.haml] }
 


### PR DESCRIPTION
This commit processes files in parallel to speed them up.

## Results on my Rails app

### v0.35.0

```
$ time bundle exec haml-lint app/views
1158 files inspected, 0 lints detected
bundle exec haml-lint app/views  77.61s user 2.19s system 96% cpu 1:22.61 total
```

### parallel

```
$ time bundle exec haml-lint --parallel app/views
1158 files inspected, 0 lints detected
bundle exec haml-lint --parallel app/views  130.37s user 2.81s system 328% cpu 40.480 total
```