### PR TITLE
Allow haml 5.2

### DIFF
--- a/haml_lint.gemspec
+++ b/haml_lint.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.4.0'
 
-  s.add_dependency 'haml', '>= 4.0', '< 5.2'
+  s.add_dependency 'haml', '>= 4.0', '< 5.3'
   s.add_dependency 'parallel', '~> 1.10'
   s.add_dependency 'rainbow'
   s.add_dependency 'rubocop', '>= 0.50.0'


### PR DESCRIPTION
I'm not familiar with the reasons behind this constraint. Perhaps there is a specific reason, or perhaps it is a normal precaution. I'm just relaxing the constraint, assuming some kind of CI will run, and that'll tell us .. something.