### PR TITLE
Reuse a shared RuboCop::CLI instance

### DIFF
--- a/lib/haml_lint/linter/rubocop.rb
+++ b/lib/haml_lint/linter/rubocop.rb
@@ -36,7 +36,7 @@ module HamlLint
     # @param source_map [Hash] map of Ruby code line numbers to original line
     #   numbers in the template
     def find_lints(ruby, source_map)
-      rubocop = ::RuboCop::CLI.new
+      @shared_rubocop ||= ::RuboCop::CLI.new
 
       filename =
         if document.file
@@ -46,7 +46,7 @@ module HamlLint
         end
 
       with_ruby_from_stdin(ruby) do
-        extract_lints_from_offenses(lint_file(rubocop, filename), source_map)
+        extract_lints_from_offenses(lint_file(@shared_rubocop, filename), source_map)
       end
     end
 

--- a/spec/haml_lint/linter/instance_variables_spec.rb
+++ b/spec/haml_lint/linter/instance_variables_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe HamlLint::Linter::InstanceVariables do
         '<%- end -%>',
         '',
         '= form.form_group :class => "form-actions" do',
+        '  = form.hidden_tag @ivar',
         '  = form.submit :class => "btn btn-primary"'
       ].join("\n")
     end
@@ -110,6 +111,11 @@ RSpec.describe HamlLint::Linter::InstanceVariables do
       expect { subject }.not_to raise_error
     end
 
-    it { should report_lint line: 1, message: 'unterminated string meets end of file' }
+    # With ruby 2.7 & v3 of the Parser gem, we can now skip past the 'invalid' ERB syntax
+    if RUBY_VERSION < '2.7'
+      it { should report_lint line: 1, message: 'unterminated string meets end of file' }
+    else
+      it { should report_lint line: 6, message: 'Avoid using instance variables in partials views' }
+    end
   end
 end

--- a/spec/haml_lint/linter/line_length_spec.rb
+++ b/spec/haml_lint/linter/line_length_spec.rb
@@ -53,7 +53,7 @@ describe HamlLint::Linter::LineLength do
       <<-HAML
         -# haml-lint:disable LineLength
         %p{ |
-          'data-test' => link_to 'Foobar', i_need_to_make_this_line_longer_path, class: 'button alert' } |
+          'data-test' => link_to('Foobar', i_need_to_make_this_line_longer_path, class: 'button alert') } |
         -# haml-lint:enable LineLength
         %p Another really long line that should report a lint for line length because it is no longer disabled
       HAML

--- a/spec/haml_lint/linter/rubocop_spec.rb
+++ b/spec/haml_lint/linter/rubocop_spec.rb
@@ -14,7 +14,7 @@ describe HamlLint::Linter::RuboCop do
     # before linter is run
     before do
       rubocop_cli.stub(:run).and_return(::RuboCop::CLI::STATUS_SUCCESS)
-      ::RuboCop::CLI.stub(:new).and_return(rubocop_cli)
+      HamlLint::Linter::RuboCop.stub(:rubocop_cli).and_return(rubocop_cli)
       HamlLint::OffenseCollector.stub(:offenses)
                                 .and_return([offence].compact)
     end


### PR DESCRIPTION
With ruby 2.6.6, rubocop 0.93.1, and 578 view files, this change reduced our haml-lint times from 35.9s to 17.9s

This was originally proposed in https://github.com/sds/haml-lint/issues/301.  We're still calling the entire `::RuboCop::CLI#run` method on each file, but it seems like we can get a significant speed up by re-using the same CLI instance. In particular, `@config_store` keeps a cache of config file instances, so we avoid repeatedly loading .rubocop.yml.

For each directory of files that's checked, rubocop is still traversing upwards looking for a .rubocop.yml.  You can avoid that by setting `ConfigStore#options_config`, but in practice it seemed to make very little difference, and it would prevent people from having, say, a different .rubocop.yml in `app/views/admin` vs `app/views`.

Would be curious to see if other people can reproduce the improvement.