### PR TITLE
No linter include/exclude config by default

### DIFF
--- a/lib/haml_lint/configuration.rb
+++ b/lib/haml_lint/configuration.rb
@@ -97,7 +97,7 @@ module HamlLint
     def validate
       ensure_exclude_option_array_exists
       ensure_linter_section_exists
-      ensure_linter_include_exclude_arrays_exist
+      ensure_linter_include_exclude_arrays
       ensure_linter_severity_valid
     end
 
@@ -113,11 +113,11 @@ module HamlLint
 
     # Ensure `include` and `exclude` options for linters are arrays
     # (since users can specify a single string glob pattern for convenience)
-    def ensure_linter_include_exclude_arrays_exist
+    def ensure_linter_include_exclude_arrays
       @hash['linters'].each_key do |linter_name|
         %w[include exclude].each do |option|
           linter_config = @hash['linters'][linter_name]
-          linter_config[option] = Array(linter_config[option])
+          linter_config[option] = Array(linter_config[option]) if linter_config[option]
         end
       end
     end

--- a/lib/haml_lint/linter_selector.rb
+++ b/lib/haml_lint/linter_selector.rb
@@ -64,7 +64,7 @@ module HamlLint
     def run_linter_on_file?(config, linter, file)
       linter_config = config.for_linter(linter)
 
-      if linter_config['include'].any? &&
+      if linter_config['include'] &&
          !HamlLint::Utils.any_glob_matches?(linter_config['include'], file)
         return false
       end

--- a/spec/haml_lint/configuration_spec.rb
+++ b/spec/haml_lint/configuration_spec.rb
@@ -76,4 +76,34 @@ describe HamlLint::Configuration do
       end
     end
   end
+
+  describe '#merge' do
+    let(:config) { described_class.new(old_hash) }
+    subject { config.merge(described_class.new(new_hash)) }
+
+    context 'when exclude is not explicitly declared on child configuration' do
+      let(:old_hash) do
+        {
+          'linters' => {
+            'SomeLinter' => {
+              'exclude' => ['**/*.ignore.haml'],
+            },
+          },
+        }
+      end
+      let(:new_hash) do
+        {
+          'linters' => {
+            'SomeLinter' => {
+              'enabled' => true,
+            },
+          },
+        }
+      end
+
+      it 'uses inherited exclude' do
+        subject['linters']['SomeLinter']['exclude'].should == ['**/*.ignore.haml']
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #332.

Currently every linter is ensured to have `include` and `exclude` configuration by default. This does not play nice when merging two configurations, since it overwrites the old one.

Another idea is to change the merge behavior instead, such that it only overwrites if the new array is not empty. However this will hinder the possibility to overwrite old `include`/`exclude` config with empty array.