### PR TITLE
Adds OffensecountReporter and unit tests

### DIFF
--- a/lib/haml_lint/reporter/offensecount_reporter.rb
+++ b/lib/haml_lint/reporter/offensecount_reporter.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: false
+
+module HamlLint
+  # Outputs the a list of lints with a count of how many of each were found.
+  # Ordered by descending count
+  class Reporter::OffensecountReporter < Reporter
+    def display_report(report)
+      lints = report.lints
+      total_count = lints.count
+      return if total_count.zero?
+
+      lints.group_by {|l| l.linter.name }
+           .map { |linter, lints_for_this_linter| [linter, lints_for_this_linter.size] }.to_h
+           .sort_by { |_linter, lint_count| -lint_count }
+           .each do |linter, lint_count|
+             log.log "#{lint_count.to_s.ljust(total_count.to_s.length + 2)} #{linter}"
+      end
+
+      log.log '--'
+      log.log "#{total_count}  Total"
+    end
+  end
+end

--- a/lib/haml_lint/reporter/offensecount_reporter.rb
+++ b/lib/haml_lint/reporter/offensecount_reporter.rb
@@ -9,7 +9,7 @@ module HamlLint
       total_count = lints.count
       return if total_count.zero?
 
-      lints.group_by {|l| l.linter.name }
+      lints.group_by {|l| lint_type_group(l) }
            .map { |linter, lints_for_this_linter| [linter, lints_for_this_linter.size] }.to_h
            .sort_by { |_linter, lint_count| -lint_count }
            .each do |linter, lint_count|
@@ -18,6 +18,16 @@ module HamlLint
 
       log.log '--'
       log.log "#{total_count}  Total"
+    end
+
+    private
+
+    def lint_type_group(lint)
+      "#{lint.linter.name}#{offense_type(lint)}"
+    end
+
+    def offense_type(lint)
+      ": #{lint.message.to_s.split(':')[0]}" if lint.linter.name == 'RuboCop'
     end
   end
 end

--- a/spec/haml_lint/reporter/offensecount_reporter_spec.rb
+++ b/spec/haml_lint/reporter/offensecount_reporter_spec.rb
@@ -54,6 +54,28 @@ RSpec.describe HamlLint::Reporter::OffensecountReporter do
         first_line.should start_with('2 ')
         second_line.should start_with('1 ')
       end
+
+      context 'when the linter is RuboCop' do
+        let(:linter) { [double(name: 'RuboCop', message: descriptions[0])] }
+        let(:filenames) { %w[some-filename.haml] }
+        let(:lines) { %w[502] }
+        let(:descriptions) { ['Offense: Description of lint'] }
+        let(:severities) { %i[warning] }
+
+        let(:lints) do
+          filenames.each_with_index.map do |filename, index|
+            HamlLint::Lint.new(linter[index],
+                               filename,
+                               lines[index],
+                               descriptions[index],
+                               severities[index])
+          end
+        end
+        it 'prints the name of each linter' do
+          subject
+          output.should match 'RuboCop: Offense'
+        end
+      end
     end
   end
 end

--- a/spec/haml_lint/reporter/offensecount_reporter_spec.rb
+++ b/spec/haml_lint/reporter/offensecount_reporter_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe HamlLint::Reporter::OffensecountReporter do
+  let(:files) { ['some-filename.haml'] }
+  let(:io) { StringIO.new }
+  let(:output) { io.string }
+  let(:logger) { HamlLint::Logger.new(io) }
+  let(:report) { HamlLint::Report.new(lints: lints, files: files, reporter: reporter) }
+  let(:reporter) { described_class.new(logger) }
+
+  describe '#display_report' do
+    subject { reporter.display_report(report) }
+
+    context 'when there are no lints' do
+      let(:lints) { [] }
+
+      it 'prints nothing' do
+        subject
+        output.should == ''
+      end
+    end
+
+    context 'when there are lints' do
+      let(:linter) { [double(name: 'SomeLinter'), double(name: 'DifferentLinter'), double(name: 'SomeLinter')] }
+      let(:filenames) { %w[some-filename.haml other-filename.haml thirdfilename.haml] }
+      let(:lines) { %w[502 724 222] }
+      let(:descriptions) { ['Description of lint 1', 'Description of "lint" 2', 'Description 3'] }
+      let(:severities) { %i[warning error warning] }
+
+      let(:lints) do
+        filenames.each_with_index.map do |filename, index|
+          HamlLint::Lint.new(linter[index],
+                             filename,
+                             lines[index],
+                             descriptions[index],
+                             severities[index])
+        end
+      end
+
+      it 'prints the name of each linter' do
+        subject
+        output.should match linter[0].name
+        output.should match linter[1].name
+      end
+
+      it 'prints a line for each linter' do
+        subject
+        output.split('--')[0].count("\n").should == 2
+      end
+
+      it 'prints the count of how many of each lint were found in descending order' do
+        subject
+        first_line, second_line = output.split("\n")
+        first_line.should start_with('2 ')
+        second_line.should start_with('1 ')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds an offense count reporter in the style of rubocop's offense count formatter. It simply prints out the number of lints for each linter in descending order. For RuboCop lints, it will group by `"RuboCop: <offense name>"` which it extracts from the message. Thank you for your consideration :-)