### PR TITLE
Fix inherits_from global configuration option to not be ignored

### DIFF
--- a/lib/haml_lint/configuration.rb
+++ b/lib/haml_lint/configuration.rb
@@ -73,6 +73,8 @@ module HamlLint
         case old
         when Hash
           smart_merge(old, new)
+        when Array
+          old | new
         else
           new
         end

--- a/spec/haml_lint/configuration_spec.rb
+++ b/spec/haml_lint/configuration_spec.rb
@@ -81,7 +81,7 @@ describe HamlLint::Configuration do
     let(:config) { described_class.new(old_hash) }
     subject { config.merge(described_class.new(new_hash)) }
 
-    context 'when exclude is not explicitly declared on child configuration' do
+    context 'when `exclude` is not explicitly declared on child configuration' do
       let(:old_hash) do
         {
           'linters' => {
@@ -101,8 +101,34 @@ describe HamlLint::Configuration do
         }
       end
 
-      it 'uses parent exclude' do
+      it 'uses parent `exclude`' do
         subject['linters']['SomeLinter']['exclude'].should == ['**/*.ignore.haml']
+      end
+    end
+
+    context 'when `include` is declared on both parent and child configuration' do
+      let(:old_hash) do
+        {
+          'linters' => {
+            'SomeLinter' => {
+              'enabled' => true,
+              'include' => ['some-filename.haml'],
+            },
+          },
+        }
+      end
+      let(:new_hash) do
+        {
+          'linters' => {
+            'SomeLinter' => {
+              'include' => ['other-filename.haml'],
+            },
+          },
+        }
+      end
+
+      it 'uses both parent and child `include`' do
+        subject['linters']['SomeLinter']['include'].should == ['some-filename.haml', 'other-filename.haml']
       end
     end
   end


### PR DESCRIPTION
The `smart_merge` method did not reflect the `child` configuration when merging keys with array values, so it has been changed to reflect both the `parent` and `child` configurations.

Fixes #311 