### PR TITLE
Fix typo in linter doc for RubyComments

### DIFF
--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -594,7 +594,7 @@ AllCops:
 
 Prefer HAML's built-in comment over ad hoc comments in Ruby code.
 
-**Bad: Space after `#` means comment is actually treated as Ruby code**
+**Bad: Space before `#` means comment is actually treated as Ruby code**
 ```haml
 - # A Ruby comment
 ```


### PR DESCRIPTION
"Space after `#` means comment is actually treated as Ruby code" is wrong.

2 options, I went with the first:

* Space before `#` ...
* Space after `-` ...