### PR TITLE
Set up code coverage reporting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,13 +8,12 @@ on:
 jobs:
   rspec:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
 
     strategy:
       matrix:
         os:
-          - windows-latest
-          - ubuntu-latest
+          - ubuntu
         ruby-version:
           - '2.6'
           - '2.7'
@@ -36,3 +35,21 @@ jobs:
 
       - name: Run tests
         run: bundle exec rspec
+
+      - name: Code coverage reporting
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          flag-name: run-${{ matrix.test_number }}-${{ matrix.os }}-${{ matrix.ruby-version }}-${{ matrix.gemfile }}
+          parallel: true
+
+  finish:
+    needs: rspec
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Finalize code coverage report
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          parallel-finished: true

--- a/.simplecov
+++ b/.simplecov
@@ -1,4 +1,0 @@
-SimpleCov.start do
-  add_filter '/bin/'
-  add_filter '/spec/'
-end

--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,5 @@ gem 'overcommit', '0.58.0'
 # Pin tool versions (which are executed by Overcommit) for CI builds
 gem 'rubocop', '0.79.0'
 
-gem 'coveralls', require: false
+gem 'simplecov', '~> 0.21.0'
+gem 'simplecov-lcov', '~> 0.8.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,20 @@
 # frozen_string_literal: true
 
-if ENV['CI']
-  # When running in CI, report coverage stats to Coveralls.
-  require 'coveralls'
-  Coveralls.wear!
-else
-  # Otherwise render coverage information in coverage/index.html and display
-  # coverage percentage in the console.
-  require 'simplecov'
+require 'simplecov'
+SimpleCov.start do
+  add_filter '/bin/'
+  add_filter '/spec/'
+
+  if ENV['CI']
+    require 'simplecov-lcov'
+
+    SimpleCov::Formatter::LcovFormatter.config do |c|
+      c.report_with_single_file = true
+      c.single_report_path = 'coverage/lcov.info'
+    end
+
+    formatter SimpleCov::Formatter::LcovFormatter
+  end
 end
 
 # Disable colors in tests because we don't normally want to test it


### PR DESCRIPTION
Switch to the GitHub Actions-based code coverage reporting.