### PR TITLE
Cut version 0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HAML-Lint Changelog
 
+### 0.39.0
+
+* Revert change to `SpaceInsideHashAttribute` since it was not compatible across all HAML versions
+
 ### 0.38.0
 
 * Fix config merging behavior so new empty array (the default) does not overwrite old array

--- a/lib/haml_lint/version.rb
+++ b/lib/haml_lint/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 module HamlLint
-  VERSION = '0.38.0'
+  VERSION = '0.39.0'
 end


### PR DESCRIPTION
* Revert change to `SpaceInsideHashAttribute` since it was not compatible across all HAML versions
