### PR TITLE
Allow for hash attribute to be on separate lines

### DIFF
--- a/lib/haml_lint/linter/space_inside_hash_attributes.rb
+++ b/lib/haml_lint/linter/space_inside_hash_attributes.rb
@@ -9,15 +9,15 @@ module HamlLint
     STYLE = {
       'no_space' => {
         start_regex: /\A\{[^ ]/,
-        end_regex: /[^ ]\}\z/,
+        end_regex: /(?:^\s*\}|[^ ]\})\z/,
         start_message: 'Hash attribute should start with no space after the opening brace',
-        end_message: 'Hash attribute should end with no space before the closing brace'
+        end_message: 'Hash attribute should end with no space before the closing brace or be on its own line'
       },
       'space' => {
-        start_regex: /\A\{ [^ ]/,
-        end_regex: /[^ ] \}\z/,
+        start_regex: /\A\{(?: [^ ]|$)/,
+        end_regex: /(?:^\s*\}|[^ ] \})\z/,
         start_message: 'Hash attribute should start with one space after the opening brace',
-        end_message: 'Hash attribute should end with one space before the closing brace'
+        end_message: 'Hash attribute should end with one space before the closing brace or be on its own line'
       }
     }.freeze
 

--- a/spec/haml_lint/linter/space_inside_hash_attributes_spec.rb
+++ b/spec/haml_lint/linter/space_inside_hash_attributes_spec.rb
@@ -106,4 +106,111 @@ describe HamlLint::Linter::SpaceInsideHashAttributes do
       it { should report_lint }
     end
   end
+
+  # Multiline attributes were introduced in 5.2.1
+  if Haml::VERSION >= '5.2.1'
+    context 'when a tag contains multi-line attributes' do
+      context 'with the first and last attributes on the same line as the brace and both separated by a space' do
+        let(:haml) do
+          <<~HAML
+            .container
+              %tag{ lang: 'en',
+                near: true,
+                last: 'one' }
+          HAML
+        end
+
+        context 'default config (space)' do
+          it { should_not report_lint }
+        end
+
+        context 'with no_space config' do
+          let(:config) { super().merge('style' => 'no_space') }
+          it { should report_lint }
+        end
+      end
+
+      context 'with the first and last attribute on the same line as the brace without a leading space' do
+        let(:haml) do
+          <<~HAML
+            .container
+              %tag{lang: 'en',
+                near: true,
+                last: 'one' }
+          HAML
+        end
+
+        context 'default config (space)' do
+          it { should report_lint }
+        end
+
+        context 'with no_space config' do
+          let(:config) { super().merge('style' => 'no_space') }
+          it { should report_lint }
+        end
+      end
+
+      context 'with the first and last attribute on the same line as the brace without a trailing space' do
+        let(:haml) do
+          <<~HAML
+            .container
+              %tag{ lang: 'en',
+                near: true,
+                last: 'one'}
+          HAML
+        end
+
+        context 'default config (space)' do
+          it { should report_lint }
+        end
+
+        context 'with no_space config' do
+          let(:config) { super().merge('style' => 'no_space') }
+          it { should report_lint }
+        end
+      end
+
+      context 'with the first and last attribute on the same line as the brace without being separated by a space' do
+        let(:haml) do
+          <<~HAML
+            .container
+              %tag{lang: 'en',
+                near: true,
+                last: 'one'}
+          HAML
+        end
+
+        context 'default config (space)' do
+          it { should report_lint }
+        end
+
+        context 'with no_space config' do
+          let(:config) { super().merge('style' => 'no_space') }
+          it { should_not report_lint }
+        end
+      end
+
+      context 'with the first and last attribute on a separate lines from the brace' do
+        let(:haml) do
+          <<~HAML
+            .container
+              %tag{
+                lang: 'en',
+                near: true,
+                last: 'one'
+              }
+          HAML
+        end
+
+        context 'default config (space)' do
+          it { should_not report_lint }
+        end
+
+        context 'with no_space config' do
+          let(:config) { super().merge('style' => 'no_space') }
+          it { should_not report_lint }
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
When using hash attributes, the `SpaceInsideHashAttributes` should allow
the following to pass linting whether its value is set to 'spaces' or
'no_spaces':

    .container
      %my_tag{
        attr: 'one',
        next: 'attribtue',
        last: 'fun'
      }

This commit allows for that.

Fixes #357