### PR TITLE
Cut version 0.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HAML-Lint Changelog
 
+### 0.40.0
+
+* Fix `SpaceInsideHashAttribute` to allow attributes across multiple lines on HAML 5.2.
+
 ### 0.39.0
 
 * Revert change to `SpaceInsideHashAttribute` since it was not compatible across all HAML versions

--- a/lib/haml_lint/version.rb
+++ b/lib/haml_lint/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 module HamlLint
-  VERSION = '0.39.0'
+  VERSION = '0.40.0'
 end


### PR DESCRIPTION
* Fix `SpaceInsideHashAttribute` to allow attributes across multiple lines on HAML 5.2.
