### PR TITLE
Fix InstanceVariables check for multiline blocks

### DIFF
--- a/lib/haml_lint/tree/script_node.rb
+++ b/lib/haml_lint/tree/script_node.rb
@@ -9,7 +9,8 @@ module HamlLint::Tree
     #
     # @return [ParsedRuby] syntax tree in the form returned by Parser gem
     def parsed_script
-      HamlLint::ParsedRuby.new(HamlLint::RubyParser.new.parse(script))
+      statement = children.empty? ? script : script + (@value[:keyword] == 'case' ? ';when 0;end' : ';end')
+      HamlLint::ParsedRuby.new(HamlLint::RubyParser.new.parse(statement))
     end
 
     # Returns the source for the script following the `-` marker.

--- a/lib/haml_lint/tree/silent_script_node.rb
+++ b/lib/haml_lint/tree/silent_script_node.rb
@@ -8,7 +8,18 @@ module HamlLint::Tree
     #
     # @return [ParsedRuby] syntax tree in the form returned by Parser gem
     def parsed_script
-      HamlLint::ParsedRuby.new(HamlLint::RubyParser.new.parse(script))
+      statement =
+        case keyword = @value[:keyword]
+        when 'else', 'elsif'
+          'if 0;' + script + ';end'
+        when 'when'
+          'case;' + script + ';end'
+        when 'rescue', 'ensure'
+          'begin;' + script + ';end'
+        else
+          children.empty? ? script : script + (keyword == 'case' ? ';when 0;end' : ';end')
+        end
+      HamlLint::ParsedRuby.new(HamlLint::RubyParser.new.parse(statement))
     end
 
     # Returns the source for the script following the `-` marker.

--- a/spec/haml_lint/linter/instance_variables_spec.rb
+++ b/spec/haml_lint/linter/instance_variables_spec.rb
@@ -49,6 +49,179 @@ RSpec.describe HamlLint::Linter::InstanceVariables do
 
         it { should report_lint line: 1 }
       end
+
+      context 'single line if in a script node' do
+        let(:haml) { '= if conditional; @true; else false; end' }
+
+        it { should report_lint line: 1 }
+      end
+
+      context 'single line if in a silent script node' do
+        let(:haml) { '- result = if conditional; true; else @false; end' }
+
+        it { should report_lint line: 1 }
+      end
+
+      context 'as an if conditional' do
+        let(:haml) do
+          [
+            '- if @conditional',
+            '  %p true'
+          ].join("\n")
+        end
+
+        it { should report_lint line: 1 }
+      end
+
+      context 'as an elsif conditional' do
+        let(:haml) do
+          [
+            '- if false',
+            '  %p first',
+            '- elsif @conditional',
+            '  %p second'
+          ].join("\n")
+        end
+
+        it { should report_lint line: 3 }
+      end
+
+      context 'as an unless conditional' do
+        let(:haml) do
+          [
+            '- unless @conditional',
+            '  %p false'
+          ].join("\n")
+        end
+
+        it { should report_lint line: 1 }
+      end
+
+      context 'as a while conditional' do
+        let(:haml) do
+          [
+            '- while @conditional',
+            '  %p loop'
+          ].join("\n")
+        end
+
+        it { should report_lint line: 1 }
+      end
+
+      context 'as an until conditional' do
+        let(:haml) do
+          [
+            '- until @conditional',
+            '  %p loop'
+          ].join("\n")
+        end
+
+        it { should report_lint line: 1 }
+      end
+
+      context 'for loop in a script node' do
+        let(:haml) do
+          [
+            '= for item in @list',
+            '  - item'
+          ].join("\n")
+        end
+
+        it { should report_lint line: 1 }
+      end
+
+      context 'for loop in a silent script node' do
+        let(:haml) do
+          [
+            '- for item in @list',
+            '  = item'
+          ].join("\n")
+        end
+
+        it { should report_lint line: 1 }
+      end
+
+      context 'with an iterator in a script node' do
+        let(:haml) do
+          [
+            '= @list.each do |item|',
+            '  - item'
+          ].join("\n")
+        end
+
+        it { should report_lint line: 1 }
+      end
+
+      context 'with an iterator in a silent script node' do
+        let(:haml) do
+          [
+            '- @list.each do |item|',
+            '  = item'
+          ].join("\n")
+        end
+
+        it { should report_lint line: 1 }
+      end
+
+      context 'single line case in a script node' do
+        let(:haml) { '= case variable; when 1; @one; end' }
+
+        it { should report_lint line: 1 }
+      end
+
+      context 'single line case in a silent script node' do
+        let(:haml) { '- value = case @variable; when 1; one; end' }
+
+        it { should report_lint line: 1 }
+      end
+
+      context 'as a case variable in a script node' do
+        let(:haml) do
+          [
+            '= case @variable',
+            '- when 1',
+            '  - one'
+          ].join("\n")
+        end
+
+        it { should report_lint line: 1 }
+      end
+
+      context 'as a case variable in a silent script node' do
+        let(:haml) do
+          [
+            '- case @variable',
+            '- when 1',
+            '  %p one'
+          ].join("\n")
+        end
+
+        it { should report_lint line: 1 }
+      end
+
+      context 'as a when condition' do
+        let(:haml) do
+          [
+            '- case variable',
+            '- when @value',
+            '  %p value'
+          ].join("\n")
+        end
+
+        it { should report_lint line: 2 }
+      end
+
+      context 'as a rescue error class' do
+        let(:haml) do
+          [
+            '- begin',
+            '- rescue @error',
+            '  %p error'
+          ].join("\n")
+        end
+
+        it { should report_lint line: 2 }
+      end
     end
   end
 


### PR DESCRIPTION
Add surrounding statements and keywords to ruby script fragments
so parsed_script can return a valid abstract syntax tree.

Since parsed_script is only used by the InstanceVariable check it should
be sufficient to augment the script fragement with minimal dummy statements
to generate valid ruby syntax for the parser.  The returned AST may not
represent the actual document structure but it's suitable for detecting
usage of instance variables within the script fragment.

Append ';end' to script nodes with children to close their blocks.
As a special case we append ';when 0;end' to close case statements.
Prepend appropriate statements to script nodes with midblock keywords:
else, elsif, when, rescue, ensure

Fixes #245 #341