### PR TITLE
Keep newlines in extracted Ruby

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -97,6 +97,7 @@ linters:
       - Layout/CaseIndentation
       - Layout/ElseAlignment
       - Layout/EndOfLine
+      - Layout/FirstHashElementIndentation
       - Layout/HashAlignment
       - Layout/IndentationWidth
       - Layout/LineLength # renamed from Metrics/LineLength in rubocop 0.79.0

--- a/lib/haml_lint/ruby_extractor.rb
+++ b/lib/haml_lint/ruby_extractor.rb
@@ -69,12 +69,12 @@ module HamlLint
       # variable" lints)
       additional_attributes.each do |attributes_code|
         # Normalize by removing excess whitespace to avoid format lints
-        attributes_code = attributes_code.gsub(/\s*\n\s*/, ' ').strip
+        attributes_code = attributes_code.gsub(/\s*\n\s*/, "\n").strip
 
         # Attributes can either be a method call or a literal hash, so wrap it
         # in a method call itself in order to avoid having to differentiate the
         # two.
-        add_line("{}.merge(#{attributes_code.strip})", node)
+        add_line("{}.merge(#{attributes_code})", node)
       end
 
       check_tag_static_hash_source(node)
@@ -94,6 +94,7 @@ module HamlLint
 
     def visit_script(node)
       code = node.text
+
       add_line(code.strip, node)
 
       start_block = anonymous_block?(code) || start_block_keyword?(code)

--- a/spec/haml_lint/ruby_extractor_spec.rb
+++ b/spec/haml_lint/ruby_extractor_spec.rb
@@ -234,38 +234,41 @@ describe HamlLint::RubyExtractor do
       its(:source_map) { should == { 1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1 } }
     end
 
-    context 'with a tag with hash attributes containing a hash with newlines' do
-      let(:haml) { <<-HAML }
-        %tag{class: some_method({
+    # Multiline attributes were introduced in 5.2.1
+    if Haml::VERSION >= '5.2.1'
+      context 'with a tag with hash attributes containing a hash with newlines' do
+        let(:haml) { <<-HAML }
+          %tag{class: some_method({
+            one: 1,
+            two: 2
+          })}
+        HAML
+
+        its(:source) { should == normalize_indent(<<-RUBY).rstrip }
+          {}.merge(class: some_method({
           one: 1,
           two: 2
-        })}
-      HAML
+          }))
+          _haml_lint_puts_0 # tag
+          _haml_lint_puts_1 # tag/
+        RUBY
+      end
 
-      its(:source) { should == normalize_indent(<<-RUBY).rstrip }
-        {}.merge(class: some_method({
-        one: 1,
-        two: 2
-        }))
-        _haml_lint_puts_0 # tag
-        _haml_lint_puts_1 # tag/
-      RUBY
-    end
+      context 'with a tag with hash attributes containing a method call with newlines' do
+        let(:haml) { <<-HAML }
+          %tag{class: some_method(
+            1, 2, 3
+          )}
+        HAML
 
-    context 'with a tag with hash attributes containing a method call with newlines' do
-      let(:haml) { <<-HAML }
-        %tag{class: some_method(
+        its(:source) { should == normalize_indent(<<-RUBY).rstrip }
+          {}.merge(class: some_method(
           1, 2, 3
-        )}
-      HAML
-
-      its(:source) { should == normalize_indent(<<-RUBY).rstrip }
-        {}.merge(class: some_method(
-        1, 2, 3
-        ))
-        _haml_lint_puts_0 # tag
-        _haml_lint_puts_1 # tag/
-      RUBY
+          ))
+          _haml_lint_puts_0 # tag
+          _haml_lint_puts_1 # tag/
+        RUBY
+      end
     end
 
     context 'with a tag with 1.8-style hash attributes of string key/values' do

--- a/spec/haml_lint/ruby_extractor_spec.rb
+++ b/spec/haml_lint/ruby_extractor_spec.rb
@@ -224,12 +224,48 @@ describe HamlLint::RubyExtractor do
       HAML
 
       its(:source) { should == normalize_indent(<<-RUBY).rstrip }
-        {}.merge(one: 1, two: 2, 'three' => 3)
+        {}.merge(one: 1,
+        two: 2,
+        'three' => 3)
         _haml_lint_puts_0 # tag
         _haml_lint_puts_1 # tag/
       RUBY
 
-      its(:source_map) { should == { 1 => 1, 2 => 1, 3 => 1 } }
+      its(:source_map) { should == { 1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1 } }
+    end
+
+    context 'with a tag with hash attributes containing a hash with newlines' do
+      let(:haml) { <<-HAML }
+        %tag{class: some_method({
+          one: 1,
+          two: 2
+        })}
+      HAML
+
+      its(:source) { should == normalize_indent(<<-RUBY).rstrip }
+        {}.merge(class: some_method({
+        one: 1,
+        two: 2
+        }))
+        _haml_lint_puts_0 # tag
+        _haml_lint_puts_1 # tag/
+      RUBY
+    end
+
+    context 'with a tag with hash attributes containing a method call with newlines' do
+      let(:haml) { <<-HAML }
+        %tag{class: some_method(
+          1, 2, 3
+        )}
+      HAML
+
+      its(:source) { should == normalize_indent(<<-RUBY).rstrip }
+        {}.merge(class: some_method(
+        1, 2, 3
+        ))
+        _haml_lint_puts_0 # tag
+        _haml_lint_puts_1 # tag/
+      RUBY
     end
 
     context 'with a tag with 1.8-style hash attributes of string key/values' do


### PR DESCRIPTION
PR based on my suggestion in #361.

This basically stops HamlLint from removing the newlines from extracted Ruby code.

Before, 

```haml
%tag{class: some_method({
  one: 1,
  two: 2
})}
```

got extracted as:

```ruby
{}.merge(class: some_method({ one: 1, two: 2 })}
```

but this made RuboCop angry if you configured it to disallow spaces around the hash braces.

Now, it will be extracted as:

```ruby
{}.merge(class: some_method({
one: 1,
two: 2
}))
```

I also had to add `Layout/FirstHashElementIndentation` as a default ignored RuboCop Cop because  the indentation of the hash elements gets lost in the extraction. I think this is fine, because `Layout/HashAlignment` is already disabled.