### PR TITLE
Cut version 0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # HAML-Lint Changelog
 
-### master (unreleased)
+### 0.41.0
 
 * Add support for HAML 6 beta
+* Fix Ruby extractor to keep newlines in certain cases
 
 ### 0.40.1
 

--- a/lib/haml_lint/version.rb
+++ b/lib/haml_lint/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 module HamlLint
-  VERSION = '0.40.1'
+  VERSION = '0.41.0'
 end


### PR DESCRIPTION
* Add support for HAML 6 beta
* Fix Ruby extractor to keep newlines in certain cases
