### PR TITLE
Allow setting RuboCop config in .haml-lint.yml

### DIFF
--- a/lib/haml_lint/linter/rubocop.rb
+++ b/lib/haml_lint/linter/rubocop.rb
@@ -100,8 +100,9 @@ module HamlLint
     #
     # @return [Array<String>]
     def rubocop_flags
+      config_file = ENV['HAML_LINT_RUBOCOP_CONF'] || config['config_file']
       flags = %w[--format HamlLint::OffenseCollector]
-      flags += ['--config', ENV['HAML_LINT_RUBOCOP_CONF']] if ENV['HAML_LINT_RUBOCOP_CONF']
+      flags += ['--config', config_file] if config_file
       flags += ['--stdin']
       flags
     end

--- a/spec/haml_lint/linter/rubocop_spec.rb
+++ b/spec/haml_lint/linter/rubocop_spec.rb
@@ -70,6 +70,15 @@ describe HamlLint::Linter::RuboCop do
       end
     end
 
+    context 'with config_file config' do
+      let(:config) { { 'config_file' => '.haml-cop.yml' } }
+
+      it 'specifies the --config flag' do
+        expect(rubocop_cli)
+          .to have_received(:run).with(array_including('--config', '.haml-cop.yml'))
+      end
+    end
+
     context 'when running inspecting a file containing CRLF line endings (#GH-167)' do
       let(:haml) { "- if signed_in?(viewer)\r\n%span Stuff" }
 


### PR DESCRIPTION
**What**

This adds support for specifying custom RuboCop configuration files via `.haml-lint.yml`. Users can now add a `config_file:` option with the path to a custom RuboCop configuration to be used when running `haml-lint`.

**Why**

Having the ability to specify a custom configuration file for RuboCop for our haml views is valuable, but handling this via environment variables can be a challenge. It requires collaborators to add the env variable to their system, or use a tool like [direnv][de]. On the other hand, configuring in `.haml-lint.yml` or friends works out of the box without needing any additional setup.

**Notes**

A caveat of using a custom RuboCop configuration is that there appears to be [a bit of a performance hit][ph] when using them. Hopefully this will be resolved at some point on the RuboCop side.

[de]: https://direnv.net/
[ph]: https://github.com/rubocop/rubocop/issues/11010