### PR TITLE
Require forwardable in haml4 adapter to fix an error

### DIFF
--- a/lib/haml_lint/adapter/haml_4.rb
+++ b/lib/haml_lint/adapter/haml_4.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'forwardable'
+
 module HamlLint
   class Adapter
     # Adapts the Haml::Parser from Haml 4 for use in HamlLint


### PR DESCRIPTION
Fixes `uninitialized constant HamlLint::Adapter::Haml4::Forwardable (NameError)` error.

I am working on `macOS 12.6`, `ruby 2.7.5`, `rails 6.1.7`, ruby version manager is `asdf v0.10.2`.

`Gemfile` in my rails project has this line:
```
gem 'haml_lint', require: false
```

I have updated `haml-lint` from `0.40.0` to `0.41.0` and suddenly get this error:
```
haml-lint
Traceback (most recent call last):
	17: from /my/path/.asdf/installs/ruby/2.7.5/bin/haml-lint:23:in `<main>'
	16: from /my/path/.asdf/installs/ruby/2.7.5/bin/haml-lint:23:in `load'
	15: from /my/path/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/haml_lint-0.41.0/bin/haml-lint:4:in `<top (required)>'
	14: from /my/path/.asdf/installs/ruby/2.7.5/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	13: from /my/path/.asdf/installs/ruby/2.7.5/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	12: from /my/path/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/haml_lint-0.41.0/lib/haml_lint.rb:10:in `<top (required)>'
	11: from /my/path/.asdf/installs/ruby/2.7.5/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:94:in `require'
	10: from /my/path/.asdf/installs/ruby/2.7.5/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:94:in `require'
	 9: from /my/path/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/haml_lint-0.41.0/lib/haml_lint/document.rb:3:in `<top (required)>'
	 8: from /my/path/.asdf/installs/ruby/2.7.5/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:94:in `require'
	 7: from /my/path/.asdf/installs/ruby/2.7.5/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:94:in `require'
	 6: from /my/path/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/haml_lint-0.41.0/lib/haml_lint/adapter.rb:3:in `<top (required)>'
	 5: from /my/path/.asdf/installs/ruby/2.7.5/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:94:in `require'
	 4: from /my/path/.asdf/installs/ruby/2.7.5/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:94:in `require'
	 3: from /my/path/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/haml_lint-0.41.0/lib/haml_lint/adapter/haml_4.rb:3:in `<top (required)>'
	 2: from /my/path/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/haml_lint-0.41.0/lib/haml_lint/adapter/haml_4.rb:4:in `<module:HamlLint>'
	 1: from /my/path/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/haml_lint-0.41.0/lib/haml_lint/adapter/haml_4.rb:7:in `<class:Adapter>'
/my/path/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/haml_lint-0.41.0/lib/haml_lint/adapter/haml_4.rb:8:in `<class:Haml4>': uninitialized constant HamlLint::Adapter::Haml4::Forwardable (NameError)
```