### PR TITLE
require forwardable

### DIFF
--- a/lib/haml_lint/adapter/haml_4.rb
+++ b/lib/haml_lint/adapter/haml_4.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'forwardable'
+
 module HamlLint
   class Adapter
     # Adapts the Haml::Parser from Haml 4 for use in HamlLint


### PR DESCRIPTION
when using `haml_lint-0.41.0` with `ruby < 3` 
haml-lint fails with message: 

> uninitialized constant HamlLint::Adapter::Haml4::Forwardable

because `require 'forwardable'` was removed in newest version of `haml-6.x` [diff](https://github.com/haml/haml/compare/v5.2.2...v6.0.0#diff-cbf5e06f54ddd927351dbc638be718ccbae845d42d0c162032c77f2bb07aa4b7L3)

