### PR TITLE
Add `inherit_gem` directive

### DIFF
--- a/lib/haml_lint/configuration_loader.rb
+++ b/lib/haml_lint/configuration_loader.rb
@@ -53,8 +53,13 @@ module HamlLint
         context[:exclude_files] ||= []
         config = load_from_file(file)
 
-        [default_configuration, resolve_inheritance(config, context), config]
-          .reduce { |acc, elem| acc.merge(elem) }
+        configs = if context[:loaded_files].any?
+                    [resolve_inheritance(config, context), config]
+                  else
+                    [default_configuration, resolve_inheritance(config, context), config]
+                  end
+
+        configs.reduce { |acc, elem| acc.merge(elem) }
       rescue Psych::SyntaxError, Errno::ENOENT => e
         raise HamlLint::Exceptions::ConfigurationError,
               "Unable to load configuration from '#{file}': #{e}",

--- a/spec/haml_lint/configuration_loader_spec.rb
+++ b/spec/haml_lint/configuration_loader_spec.rb
@@ -274,6 +274,8 @@ describe HamlLint::ConfigurationLoader do
               '  AltText:',
               '    enabled: false',
               '  Indentation:',
+              '    enabled: false',
+              '  ImplicitDiv:',
               '    enabled: false'
             ].join("\n")
           end
@@ -298,7 +300,8 @@ describe HamlLint::ConfigurationLoader do
               'skip_frontmatter' => true,
               'linters' => {
                 'AltText' => { 'enabled' => true },
-                'Indentation' => { 'enabled' => true }
+                'Indentation' => { 'enabled' => true },
+                'ImplicitDiv' => { 'enabled' => false }
               }
             )
 

--- a/spec/haml_lint/configuration_loader_spec.rb
+++ b/spec/haml_lint/configuration_loader_spec.rb
@@ -311,6 +311,81 @@ describe HamlLint::ConfigurationLoader do
         end
       end
     end
+
+    context 'with an "inherit_gem" directive' do
+      before do
+        File.open(file_name, 'w') { |f| f.write(config_file) }
+      end
+
+      context 'for a missing gem' do
+        let(:config_file) { normalize_indent(<<-CONF) }
+          inherit_gem:
+            foobar: .haml-lint.yml
+        CONF
+
+        it 'raises an error' do
+          expect { subject }.to raise_error Gem::LoadError
+        end
+      end
+
+      context 'with a present gem' do
+        let(:config_file) { normalize_indent(<<-CONF) }
+          inherit_gem:
+            gem_one: .haml-lint.yml
+            gem_two: config/.default.yml
+        CONF
+
+        let(:gem_root) { File.expand_path('gems') }
+        let(:gem_one_config_path) { File.join(gem_root, 'gem_one', '.haml-lint.yml') }
+        let(:gem_two_config_path) { File.join(gem_root, 'gem_two', 'config', '.default.yml') }
+
+        before do
+          %w[gem_one gem_two].each do |gem_name|
+            mock_spec = double
+            mock_spec.stub(:gem_dir) { File.join(gem_root, gem_name) }
+            Gem::Specification.stub(:find_by_name).with(gem_name) { mock_spec }
+          end
+          Gem.stub(:path) { [gem_root] }
+
+          gem_one_config = <<~CONF
+            linters:
+              AlignmentTabs:
+                enabled: false
+              AltText:
+                enabled: true
+          CONF
+
+          gem_two_config = <<~CONF
+            linters:
+              AlignmentTabs:
+                enabled: true
+              ImplicitDiv:
+                enabled: false
+          CONF
+
+          # make folders for "gems"
+          FileUtils.mkdir_p(File.join(gem_root, 'gem_one'))
+          FileUtils.mkdir_p(File.join(gem_root, 'gem_two', 'config'))
+
+          # Create config files for "gems"
+          File.open(gem_one_config_path, 'w') { |f| f.write(gem_one_config) }
+          File.open(gem_two_config_path, 'w') { |f| f.write(gem_two_config) }
+        end
+
+        it 'should not raise an error' do
+          custom_config = HamlLint::Configuration.new(
+            'inherits_from' => [gem_one_config_path, gem_two_config_path],
+            'linters' => {
+              'AlignmentTabs' => { 'enabled' => true },
+              'AltText' => { 'enabled' => true },
+              'ImplicitDiv' => { 'enabled' => false }
+            }
+          )
+
+          subject.should == described_class.default_configuration.merge(custom_config)
+        end
+      end
+    end
   end
 
   describe '.load_hash' do


### PR DESCRIPTION
Hello

I'd have the same requirement for the gem as the one written in #323 .

I implemented the `inherit_gem` directive analogue to the handling in the `rubocop` gem.

During testing, I noticed that the default config gets applied to the inherited configs as well, and as such did not work well when multiple inherited files were specified. Please see the changes from the commit `d8174a9` for the changes. Before that change, the `ImplicitDiv` directive was still set to `enabled` in the final output, which probably was wrong (please let me know if I misunderstood the inheritance).

The second commit `31bbda5` then adds the `inherit_gem` directive and some unit tests.

Please let me know if any other changes are required or if I should add some docs to the readme about this feature. Otherwise I'd be delighted if this change got merged, such that my requiremend can be fullfilled.

Cheers

Adrian