### PR TITLE
Bump Ruby 2.6 as minimum version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   Exclude:
     - 'gemfiles/**'
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
 
 Lint/AmbiguousRegexpLiteral:
   Enabled: false

--- a/haml_lint.gemspec
+++ b/haml_lint.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.files            = Dir['config/**.yml'] +
                        Dir['lib/**/*.rb']
 
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.6.0'
 
   s.add_dependency 'haml', '>= 4.0', '< 6.2'
   s.add_dependency 'parallel', '~> 1.10'

--- a/lib/haml_lint/linter_registry.rb
+++ b/lib/haml_lint/linter_registry.rb
@@ -27,11 +27,9 @@ module HamlLint
       # @return [Array<Class>]
       def extract_linters_from(linter_names)
         linter_names.map do |linter_name|
-          begin
-            HamlLint::Linter.const_get(linter_name)
-          rescue NameError
-            raise NoSuchLinter, "Linter #{linter_name} does not exist"
-          end
+          HamlLint::Linter.const_get(linter_name)
+        rescue NameError
+          raise NoSuchLinter, "Linter #{linter_name} does not exist"
         end
       end
     end

--- a/spec/haml_lint/document_spec.rb
+++ b/spec/haml_lint/document_spec.rb
@@ -82,11 +82,9 @@ describe HamlLint::Document do
       end
 
       it 'includes the line number in the exception' do
-        begin
-          subject
-        rescue HamlLint::Exceptions::ParseError => e
-          e.line.should == 2
-        end
+        subject
+      rescue HamlLint::Exceptions::ParseError => e
+        e.line.should == 2
       end
     end
 


### PR DESCRIPTION
Synce to match what's being tested in CI now. I believe 2.7 hits end of life in a few weeks as well