### PR TITLE
Fix more erroneous Style/IdenticalConditionalBranches warnings

### DIFF
--- a/lib/haml_lint/ruby_extractor.rb
+++ b/lib/haml_lint/ruby_extractor.rb
@@ -73,8 +73,9 @@ module HamlLint
 
         # Attributes can either be a method call or a literal hash, so wrap it
         # in a method call itself in order to avoid having to differentiate the
-        # two.
-        add_line("{}.merge(#{attributes_code})", node)
+        # two. Use the tag name for the method to differentiate different tag types
+        # for RuboCop and prevent erroneous warnings.
+        add_line("#{node.tag_name}(#{attributes_code})", node)
       end
 
       check_tag_static_hash_source(node)

--- a/spec/haml_lint/ruby_extractor_spec.rb
+++ b/spec/haml_lint/ruby_extractor_spec.rb
@@ -137,7 +137,7 @@ describe HamlLint::RubyExtractor do
       HAML
 
       its(:source) { should == normalize_indent(<<-RUBY).rstrip }
-        {}.merge(one: 1, two: 2, 'three' => some_method)
+        tag(one: 1, two: 2, 'three' => some_method)
         _haml_lint_puts_0 # tag
         _haml_lint_puts_1 # tag/
       RUBY
@@ -165,7 +165,7 @@ describe HamlLint::RubyExtractor do
       HAML
 
       its(:source) { should == normalize_indent(<<-RUBY.rstrip) }
-        {}.merge(:type=>'checkbox', special: 'true')
+        tag(:type=>'checkbox', special: 'true')
         _haml_lint_puts_0 # tag
         _haml_lint_puts_1 # tag/
       RUBY
@@ -179,7 +179,7 @@ describe HamlLint::RubyExtractor do
       HAML
 
       its(:source) { should == normalize_indent(<<-RUBY.rstrip) }
-        {}.merge(tag_options_method)
+        tag(tag_options_method)
         _haml_lint_puts_0 # tag
         _haml_lint_puts_1 # tag/
       RUBY
@@ -193,7 +193,7 @@ describe HamlLint::RubyExtractor do
       HAML
 
       its(:source) { should == normalize_indent(<<-RUBY).rstrip }
-        {}.merge({\"one\" => 1,\"two\" => 2,\"three\" => some_method,})
+        tag({\"one\" => 1,\"two\" => 2,\"three\" => some_method,})
         _haml_lint_puts_0 # tag
         _haml_lint_puts_1 # tag/
       RUBY
@@ -207,7 +207,7 @@ describe HamlLint::RubyExtractor do
       HAML
 
       its(:source) { should == normalize_indent(<<-RUBY).rstrip }
-        {}.merge(one: 1)
+        tag(one: 1)
         _haml_lint_puts_0 # tag
         script
         _haml_lint_puts_1 # tag/
@@ -224,7 +224,7 @@ describe HamlLint::RubyExtractor do
       HAML
 
       its(:source) { should == normalize_indent(<<-RUBY).rstrip }
-        {}.merge(one: 1,
+        tag(one: 1,
         two: 2,
         'three' => 3)
         _haml_lint_puts_0 # tag
@@ -245,7 +245,7 @@ describe HamlLint::RubyExtractor do
         HAML
 
         its(:source) { should == normalize_indent(<<-RUBY).rstrip }
-          {}.merge(class: some_method({
+          tag(class: some_method({
           one: 1,
           two: 2
           }))
@@ -262,7 +262,7 @@ describe HamlLint::RubyExtractor do
         HAML
 
         its(:source) { should == normalize_indent(<<-RUBY).rstrip }
-          {}.merge(class: some_method(
+          tag(class: some_method(
           1, 2, 3
           ))
           _haml_lint_puts_0 # tag


### PR DESCRIPTION
Fixes a bug where a conditional leads to different tag types with the same data attributes such as cause erroneous `Style/IdenticalConditionalBranches` reports from rubocop.

In place of just using the generic `{}.merge` to wrap any/all attribute hashes that the extractor encounters, we can scope the attribute representations to their tag type by just using the tag's name as the method method.

e.g. for the following snippet

```haml
- if foo
  %div{ data: somedata }
    A
- else
  %span{ data: somedata }
    B
```

the extractor will now generate

```ruby
if foo
  div(data: somedata)
  ...
else
  span(data: somedata)
  ...
end
```

which rubocop will recognize as unique and therefore ignore.

Closes #378