### PR TITLE
Add NoPlaceholders linter

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -76,6 +76,9 @@ linters:
   MultilineScript:
     enabled: true
 
+  NoPlaceholders:
+    enabled: false
+
   ObjectReferenceAttributes:
     enabled: true
 

--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -21,6 +21,7 @@ Below is a list of linters supported by `haml-lint`, ordered alphabetically.
 * [LineLength](#linelength)
 * [MultilinePipe](#multilinepipe)
 * [MultilineScript](#multilinescript)
+* [NoPlaceholders](#noplaceholders)
 * [ObjectReferenceAttributes](#objectreferenceattributes)
 * [RepeatedId](#repeatedid)
 * [RuboCop](#rubocop)
@@ -500,6 +501,24 @@ will compile and run:
 ```
 
 Thus it's best to stay away from writing code this way.
+
+## NoPlaceholders
+
+Don't use HTML placeholder attributes.
+
+**Bad**
+```haml
+%input{ placeholder: 'Placeholders arent very accessible' }
+```
+
+**Good**
+```haml
+#my-details Placeholders arent very accessible
+%input{ 'aria-describedby': 'my-details' }
+```
+
+Placeholder attributes are considered an
+[anti-pattern](https://www.smashingmagazine.com/2018/06/placeholder-attribute/).
 
 ## ObjectReferenceAttributes
 

--- a/lib/haml_lint/linter/no_placeholders.rb
+++ b/lib/haml_lint/linter/no_placeholders.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module HamlLint
+  # Checks that placeholder attributes are not used.
+  class Linter::NoPlaceholders < Linter
+    include LinterRegistry
+
+    MSG = 'Placeholders attributes should not be used.'
+    HASH_REGEXP = /:?['"]?placeholder['"]?(?::| *=>)/.freeze
+    HTML_REGEXP = /placeholder=/.freeze
+
+    def visit_tag(node)
+      return unless node.hash_attributes_source =~ HASH_REGEXP || node.html_attributes_source =~ HTML_REGEXP
+
+      record_lint(node, MSG)
+    end
+  end
+end

--- a/spec/haml_lint/linter/no_placeholders_spec.rb
+++ b/spec/haml_lint/linter/no_placeholders_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+describe HamlLint::Linter::NoPlaceholders do
+  include_context 'linter'
+
+  context 'with a generic tag' do
+    let(:haml) { '%tag' }
+
+    it { should_not report_lint }
+  end
+
+  context 'when a tag has an unrelated hash attribute with placeholder as a value' do
+    let(:haml) { "%tag{ unrelated_attribute: 'placeholder' }" }
+
+    it { should_not report_lint }
+  end
+
+  ['placeholder:',
+   'placeholder: ',
+   "'placeholder':",
+   '"placeholder":',
+   ':placeholder=>',
+   ':placeholder => ',
+   "'placeholder' => ",
+   '"placeholder" => '].each do |key_format|
+    context 'when tag has a hash-style placeholder attribute' do
+      let(:haml) { "%tag{ #{key_format}'my placeholder' } " }
+
+      it { should report_lint(count: 1) }
+      it { should report_lint(message: 'Placeholders attributes should not be used.') }
+    end
+  end
+
+  context 'when a tag has an html-style placeholder attribute' do
+    let(:haml) { '%tag(placeholder="my placeholder")' }
+
+    it { should report_lint(count: 1) }
+    it { should report_lint(message: 'Placeholders attributes should not be used.') }
+  end
+end


### PR DESCRIPTION
Implements a `NoPlaceholders` linter to ensure placeholder attributes are not used. It is supported by regex matching against the source hash/html attributes that searches for `placeholder` keys.

Closes #371