### PR TITLE
Rubocop: Avoid failing for complicated situations with multiline code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HAML-Lint Changelog
 
+* Bugfixes related to experimental auto-correct
+
 ## 0.46.0
 
 * Add ERB pre-processing for configuration files

--- a/lib/haml_lint/ruby_extraction/chunk_extractor.rb
+++ b/lib/haml_lint/ruby_extraction/chunk_extractor.rb
@@ -425,6 +425,10 @@ module HamlLint::RubyExtraction
       regexp = Regexp.new(regexp_code)
 
       match = raw_haml.match(regexp)
+      # This can happen when pipes are used as marker for multiline parts, and when tag attributes change lines
+      # without ending by a comma. This is quite a can of worm and is probably not too frequent, so for now,
+      # these cases are not supported.
+      return if match.nil?
 
       raw_ruby = match[0]
       ruby_lines = raw_ruby.split("\n")

--- a/spec/haml_lint/linter/rubocop_autocorrect_examples/multiline_examples.txt
+++ b/spec/haml_lint/linter/rubocop_autocorrect_examples/multiline_examples.txt
@@ -33,7 +33,7 @@ SKIP
   hello: 123, |
   spam: 42 }
 
-!!! Multiline tag attributes with comma then pipe within string is ignored (pipe not supported)
+!!! Multiline tag attributes with comma then pipe within string is ignored (pipe not supported) {% haml_version >= '5.2' %}
 %span{ foo: "bar",
   spam: 'Text1    |
   and more' }
@@ -46,7 +46,7 @@ SKIP
   spam: 'Text1    |
   and more' }
 
-!!! Multiline tag attributes with comma then no marker is ignored (multiline without comma not supported)
+!!! Multiline tag attributes with comma then no marker is ignored (multiline without comma not supported) {% haml_version >= '5.2' %}
 %span{ foo: "bar",
   spam:
    42}
@@ -59,7 +59,7 @@ SKIP
   spam:
    42}
 
-!!! Multiline tag attributes without marker is ignored (multiline without comma not supported)
+!!! Multiline tag attributes without marker is ignored (multiline without comma not supported) {% haml_version >= '5.2' %}
 %span{ foo:
   "bar"}
 ---

--- a/spec/haml_lint/linter/rubocop_autocorrect_examples/multiline_examples.txt
+++ b/spec/haml_lint/linter/rubocop_autocorrect_examples/multiline_examples.txt
@@ -1,0 +1,71 @@
+!!! Multiline tag attributes using comma only
+%span{ foo: 'bar',
+  spam: 42 }
+---
+SKIP
+---
+SKIP
+---
+%span{ foo: 'bar',
+       spam: 42 }
+
+!!! Multiline tag attributes with comma and pipe on same line is ignored (pipe not supported)
+%span{ foo: 'bar', |
+  spam: 42 }
+---
+SKIP
+---
+SKIP
+---
+%span{ foo: 'bar', |
+  spam: 42 }
+
+!!! Multiline tag attributes with comma then comma and pipe on same line is ignored (pipe not supported)
+%span{ foo: 'bar',
+  hello: 123, |
+  spam: 42 }
+---
+SKIP
+---
+SKIP
+---
+%span{ foo: 'bar',
+  hello: 123, |
+  spam: 42 }
+
+!!! Multiline tag attributes with comma then pipe within string is ignored (pipe not supported)
+%span{ foo: "bar",
+  spam: 'Text1    |
+  and more' }
+---
+SKIP
+---
+SKIP
+---
+%span{ foo: "bar",
+  spam: 'Text1    |
+  and more' }
+
+!!! Multiline tag attributes with comma then no marker is ignored (multiline without comma not supported)
+%span{ foo: "bar",
+  spam:
+   42}
+---
+SKIP
+---
+SKIP
+---
+%span{ foo: "bar",
+  spam:
+   42}
+
+!!! Multiline tag attributes without marker is ignored (multiline without comma not supported)
+%span{ foo:
+  "bar"}
+---
+SKIP
+---
+SKIP
+---
+%span{ foo:
+  "bar"}


### PR DESCRIPTION
We support multiline when the line ends with a comma. Other cases, such as using pipes and breaking line anywhere within tag attributes is not supported for now.

HAML's rule for multiline stuff are pretty hard to deal with, with special cases for different occasions, and the parser not giving all the useful information. For now, I'd rather avoid failing and see how it goes. Maybe someone needing that will do a PR for it!