### PR TITLE
Fixing Marshal.dump errors with --parallel

### DIFF
--- a/lib/haml_lint/linter.rb
+++ b/lib/haml_lint/linter.rb
@@ -112,8 +112,11 @@ module HamlLint
     #
     # @return [AST::Node]
     def parse_ruby(source)
+      self.class.ruby_parser.parse(source)
+    end
+
+    def self.ruby_parser # rubocop:disable Lint/IneffectiveAccessModifier
       @ruby_parser ||= HamlLint::RubyParser.new
-      @ruby_parser.parse(source)
     end
 
     # Remove the surrounding double quotes from a string, ignoring any

--- a/lib/haml_lint/linter/rubocop.rb
+++ b/lib/haml_lint/linter/rubocop.rb
@@ -334,7 +334,7 @@ module HamlLint
     # anymore or don't exist yet.
     # This is not exhaustive, it's only for the cops that are in config/default.yml
     def ignored_cops_flags
-      ignored_cops = config['ignored_cops']
+      ignored_cops = config.fetch('ignored_cops', [])
 
       if @autocorrect
         ignored_cops += self.class.cops_names_not_supporting_autocorrect

--- a/lib/haml_lint/linter/rubocop.rb
+++ b/lib/haml_lint/linter/rubocop.rb
@@ -52,11 +52,6 @@ module HamlLint
         return
       end
 
-      user_config_path = ENV['HAML_LINT_RUBOCOP_CONF'] || config['config_file']
-      user_config_path ||= self.class.rubocop_config_store.user_rubocop_config_path_for(document.file)
-      user_config_path = File.absolute_path(user_config_path)
-      @rubocop_config = self.class.rubocop_config_store.config_object_pointing_to(user_config_path)
-
       @last_extracted_source = nil
       @last_new_ruby_source = nil
 
@@ -101,6 +96,13 @@ module HamlLint
     end
 
     private
+
+    def rubocop_config_for(path)
+      user_config_path = ENV['HAML_LINT_RUBOCOP_CONF'] || config['config_file']
+      user_config_path ||= self.class.rubocop_config_store.user_rubocop_config_path_for(path)
+      user_config_path = File.absolute_path(user_config_path)
+      self.class.rubocop_config_store.config_object_pointing_to(user_config_path)
+    end
 
     # Extracted here so that tests can stub this to always return true
     def transfer_corrections?(initial_ruby_code, new_ruby_code)
@@ -205,7 +207,7 @@ module HamlLint
     def run_rubocop(rubocop_cli, ruby_code, path) # rubocop:disable Metrics
       rubocop_status = nil
       stdout_str, stderr_str = HamlLint::Utils.with_captured_streams(ruby_code) do
-        rubocop_cli.config_store.instance_variable_set(:@options_config, @rubocop_config)
+        rubocop_cli.config_store.instance_variable_set(:@options_config, rubocop_config_for(path))
         rubocop_status = rubocop_cli.run(rubocop_flags + ['--stdin', path])
       end
 

--- a/spec/haml_lint/linter/rubocop_spec.rb
+++ b/spec/haml_lint/linter/rubocop_spec.rb
@@ -338,7 +338,7 @@ describe HamlLint::Linter::RuboCop do
   describe '#run_rubocop' do
     subject { described_class.new(config).send(:run_rubocop, rubocop_cli, 'foo', 'some_file.rb') }
 
-    let(:config) { spy('config') }
+    let(:config) { {} }
     let(:rubocop_cli) { spy('rubocop_cli') }
 
     before do

--- a/spec/haml_lint/runner_spec.rb
+++ b/spec/haml_lint/runner_spec.rb
@@ -84,6 +84,20 @@ describe HamlLint::Runner do
           runner.should_receive(:warm_cache).and_call_original
           subject
         end
+
+        context 'when errors are present' do
+          let(:files) { %w[example.haml] }
+          include_context 'isolated environment'
+
+          before do
+            `echo "%div{ class: 'foo' } hello" > example.haml`
+          end
+
+          it 'successfully reports those errors' do
+            runner.unstub(:collect_lints)
+            expect(subject.lints.first.message).to match(/Avoid defining `class` in attributes hash/)
+          end
+        end
       end
 
       context 'when there is a Haml parsing error in a file' do


### PR DESCRIPTION
Prior to this, if you're using the `--parallel` option and linting errors get reported, it would cause Marshal.dump errors along the lines of:

```
./Users/jon/.gem/ruby/3.1.0/gems/parallel-1.22.1/lib/parallel.rb:566:in `dump': no _dump_data is defined for class Proc (TypeError)
	from /Users/jon/.gem/ruby/3.1.0/gems/parallel-1.22.1/lib/parallel.rb:566:in `process_incoming_jobs'
	from /Users/jon/.gem/ruby/3.1.0/gems/parallel-1.22.1/lib/parallel.rb:537:in `block in worker'
	from /Users/jon/.gem/ruby/3.1.0/gems/parallel-1.22.1/lib/parallel.rb:528:in `fork'
	from /Users/jon/.gem/ruby/3.1.0/gems/parallel-1.22.1/lib/parallel.rb:528:in `worker'
	from /Users/jon/.gem/ruby/3.1.0/gems/parallel-1.22.1/lib/parallel.rb:519:in `block in create_workers'
	from /Users/jon/.gem/ruby/3.1.0/gems/parallel-1.22.1/lib/parallel.rb:518:in `each'
	from /Users/jon/.gem/ruby/3.1.0/gems/parallel-1.22.1/lib/parallel.rb:518:in `each_with_index'
	from /Users/jon/.gem/ruby/3.1.0/gems/parallel-1.22.1/lib/parallel.rb:518:in `create_workers'
	from /Users/jon/.gem/ruby/3.1.0/gems/parallel-1.22.1/lib/parallel.rb:457:in `work_in_processes'
	from /Users/jon/.gem/ruby/3.1.0/gems/parallel-1.22.1/lib/parallel.rb:294:in `map'
	from /Users/jon/Developer/vendor/haml-lint/lib/haml_lint/runner.rb:181:in `warm_cache'
	from /Users/jon/Developer/vendor/haml-lint/lib/haml_lint/runner.rb:172:in `report'
	from /Users/jon/Developer/vendor/haml-lint/lib/haml_lint/runner.rb:30:in `run'
	from /Users/jon/Developer/vendor/haml-lint/spec/haml_lint/runner_spec.rb:14:in `block (3 levels) in <top (required)>'
```

We can avoid serializing procs by ensuring that the `Linter` instance doesn't contain references to RubyParser or the Rubocop config instance.

(I confess I'm not 100% sure why this doesn't seem to be a problem for everyone all the time.)

Fixes #345, #400
