### PR TITLE
Fix `Marshal.dump` error when using `--parallel` option and `RepeatedId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HAML-Lint Changelog
 
+* Fix `Marshal.dump` error when using `--parallel` option and `RepeatedId` Linter
+
 # 0.47.0
 
 * Bugfixes related to experimental auto-correct

--- a/lib/haml_lint/linter/repeated_id.rb
+++ b/lib/haml_lint/linter/repeated_id.rb
@@ -8,13 +8,14 @@ module HamlLint
     MESSAGE_FORMAT = %{Do not repeat id "#%s" on the page}
 
     def visit_root(_node)
-      @id_map = Hash.new { |hash, key| hash[key] = [] }
+      @id_map = {}
     end
 
     def visit_tag(node)
       id = node.tag_id
       return unless id && !id.empty?
 
+      id_map[id] ||= []
       nodes = (id_map[id] << node)
       case nodes.size
       when 1 then nil

--- a/spec/haml_lint/linter_spec.rb
+++ b/spec/haml_lint/linter_spec.rb
@@ -54,4 +54,25 @@ describe HamlLint::Linter do
 
     it { should == 'SomeLinterName' }
   end
+
+  # Source from https://apidock.com/rails/Class/descendants
+  linter_classes = []
+  ObjectSpace.each_object(HamlLint::Linter.singleton_class) do |k|
+    next if k.singleton_class?
+    linter_classes.unshift k unless k == self
+  end
+  linter_classes.each do |linter_class|
+    describe "subclass #{linter_class.name}" do
+      # Needed for parallel mode, because lints are dumped and they refer to the linter
+      it 'instances can be Marshal.dump' do
+        document = HamlLint::Document.new('something', config: HamlLint::ConfigurationLoader.default_configuration)
+        expect do
+          linter = linter_class.new(config)
+          linter.run(document)
+
+          Marshal.dump(linter)
+        end.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
Dumping a hash with a default proc is not possible, but --parallel needs to dump linter instances. 
This remove the only use of hash with a default proc. Also adds a basic test that checks that every linter instances can be Marshal.dump

This may be the actual cause of #345 and #400.