### PR TITLE
Improve coverage related to new Rubocop system

### DIFF
--- a/lib/haml_lint/ruby_extraction/haml_comment_chunk.rb
+++ b/lib/haml_lint/ruby_extraction/haml_comment_chunk.rb
@@ -15,26 +15,6 @@ module HamlLint::RubyExtraction
       HamlCommentChunk.new(node, @ruby_lines + following_chunk.ruby_lines, end_marker_indent: end_marker_indent)
     end
 
-    def fuse_script_chunk(following_chunk)
-      return if following_chunk.end_marker_indent.nil?
-      return if following_chunk.must_start_chunk
-
-      nb_blank_lines_between = following_chunk.haml_line_index - haml_line_index - nb_haml_lines
-      blank_lines = nb_blank_lines_between > 0 ? [''] * nb_blank_lines_between : []
-      new_lines = @ruby_lines + blank_lines + following_chunk.ruby_lines
-
-      source_map_skips = @skip_line_indexes_in_source_map
-      source_map_skips.concat(following_chunk.skip_line_indexes_in_source_map
-                                .map { |i| i + @ruby_lines.size })
-
-      ScriptChunk.new(node,
-                      new_lines,
-                      haml_line_index: haml_line_index,
-                      skip_line_indexes_in_source_map: source_map_skips,
-                      end_marker_indent: following_chunk.end_marker_indent,
-                      previous_chunk: previous_chunk)
-    end
-
     def transfer_correction_logic(_coordinator, to_ruby_lines, haml_lines)
       if to_ruby_lines.empty?
         haml_lines.slice!(@haml_line_index..haml_end_line_index)


### PR DESCRIPTION
I noticed some files are very bad coverage. Turns out there was a big unused method, and the Runner code related for auto-correction wasn't tested at all.