### PR TITLE
Suppress compliancy warning of ruby parser while requiring

### DIFF
--- a/lib/haml_lint/ruby_parser.rb
+++ b/lib/haml_lint/ruby_parser.rb
@@ -2,7 +2,6 @@
 
 require 'rubocop'
 require 'rubocop/ast/builder'
-require 'parser/current'
 
 module HamlLint
   # Parser for the Ruby language.
@@ -14,8 +13,19 @@ module HamlLint
   class RubyParser
     # Creates a reusable parser.
     def initialize
+      require_parser
       @builder = ::RuboCop::AST::Builder.new
       @parser = ::Parser::CurrentRuby.new(@builder)
+    end
+
+    # Require the current parser version while suppressing the 
+    # compliancy warning for minor version differences.
+    def require_parser
+      prev = $VERBOSE
+      $VERBOSE = nil
+      require 'parser/current'
+    ensure
+      $VERBOSE = prev
     end
 
     # Parse the given Ruby source into an abstract syntax tree.

--- a/lib/haml_lint/ruby_parser.rb
+++ b/lib/haml_lint/ruby_parser.rb
@@ -18,7 +18,7 @@ module HamlLint
       @parser = ::Parser::CurrentRuby.new(@builder)
     end
 
-    # Require the current parser version while suppressing the 
+    # Require the current parser version while suppressing the
     # compliancy warning for minor version differences.
     def require_parser
       prev = $VERBOSE


### PR DESCRIPTION
This fixes the following warning when running haml-lint:
```
warning: parser/current is loading parser/ruby31, which recognizes 3.1.3-compliant syntax, but you are running 3.1.2.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
```

The approach has been copied from the `rubocop` gem (https://github.com/marcandre/rubocop-ast/commit/7081f7cae0326150b648c54a99e124998ab2bffb).