### PR TITLE
Add Trailing Empty Lines linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HAML-Lint Changelog
 
+# unreleased
+
+* Add `TrailingEmptyLines` linter
+
 # 0.48.0
 
 * Fix `Marshal.dump` error when using `--parallel` option and `RepeatedId` Linter

--- a/config/default.yml
+++ b/config/default.yml
@@ -105,6 +105,9 @@ linters:
   TagName:
     enabled: true
 
+  TrailingEmptyLines:
+    enabled: true
+
   TrailingWhitespace:
     enabled: true
 

--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -29,6 +29,7 @@ Below is a list of linters supported by `haml-lint`, ordered alphabetically.
 * [SpaceBeforeScript](#spacebeforescript)
 * [SpaceInsideHashAttributes](#spaceinsidehashattributes)
 * [TagName](#tagname)
+* [TrailingEmptyLines](#trailingemptylines)
 * [TrailingWhitespace](#trailingwhitespace)
 * [UnnecessaryInterpolation](#unnecessaryinterpolation)
 * [UnnecessaryStringOutput](#unnecessarystringoutput)
@@ -710,6 +711,10 @@ This is a _de facto_ standard in writing HAML documents as well as HTML in
 general, as it is easier to type and matches the convention of many developer
 tools. If you are writing HAML to output XML documents, however, it is a strict
 requirement.
+
+## TrailingEmptyLines
+
+HAML documents should not contain empty lines at the end of the file.
 
 ## TrailingWhitespace
 

--- a/lib/haml_lint/linter/trailing_empty_lines.rb
+++ b/lib/haml_lint/linter/trailing_empty_lines.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module HamlLint
+  # Checks for trailing empty lines.
+  class Linter::TrailingEmptyLines < Linter
+    include LinterRegistry
+
+    DummyNode = Struct.new(:line)
+
+    def visit_root(root)
+      return if document.source.empty?
+      line_number = document.last_non_empty_line
+
+      node = root.node_for_line(line_number)
+      return if node.disabled?(self)
+
+      return unless document.source.end_with?("\n\n")
+
+      record_lint(line_number, 'Files should not end with trailing empty lines')
+    end
+  end
+end

--- a/spec/haml_lint/linter/trailing_empty_lines_spec.rb
+++ b/spec/haml_lint/linter/trailing_empty_lines_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+describe HamlLint::Linter::TrailingEmptyLines do
+  include_context 'linter'
+
+  context 'when the file is empty' do
+    let(:haml) { '' }
+
+    it { should_not report_lint }
+  end
+
+  context 'when file ends with a single newline' do
+    let(:haml) { "%h1 Hello\n" }
+
+    it { should_not report_lint }
+  end
+
+  context 'when file contains multiple newlines' do
+    let(:haml) { "%h1 Hello\n\n" }
+
+    it { should report_lint line: 1 }
+
+    context 'but the linter is disabled in the file' do
+      let(:haml) { "-# haml-lint:disable TrailingEmptyLines\n" + super() }
+
+      it { should_not report_lint }
+    end
+  end
+end


### PR DESCRIPTION
Hi,

first attempt to contribute, please let me know

---

HAML documents should not contain empty lines at the end of the file.

Inspired by Slim lint's `TrailingBlankLines`

Close #422