### PR TITLE
Fix cases where Rubocop (so Haml-Lint) indents a line too little

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # HAML-Lint Changelog
 
+* Fix some cases where part of multiline scripts could end up less indented than the
+  starting line of that script.
+
 ### 0.49.2
 
 * Fix handling of interpolation of plain when the plain is spread over multiple lines using pipes


### PR DESCRIPTION
For multiline scripts, if RuboCop's auto-correction didn't indent enough, we could end up with a "negative" indentation and so part of the multiline script would be less indented than the first line of the script, which is never correct.

One example case of this is `Layout/MultilineHashBraceLayout` with new_line mode. When it fixes, it sometimes just doesn't indent the closing brace..