### PR TITLE
Update minimum Ruby version to 2.7

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2
           bundler-cache: true
 
       - name: Prepare environment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - "2.6"
           - "2.7"
           - "3.0"
           - "3.1"

--- a/haml_lint.gemspec
+++ b/haml_lint.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.files            = Dir['config/**.yml'] +
                        Dir['lib/**/*.rb']
 
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.7.0'
 
   s.add_dependency 'haml', '>= 4.0', '< 6.2'
   s.add_dependency 'parallel', '~> 1.10'


### PR DESCRIPTION
2.6 has been EOL for over a year. While 2.7 is also technically EOL, we'll wait for a separate release before dropping support for that.
