### PR TITLE
Disable Style/RedundantStringEscape

### DIFF
--- a/config/forced_rubocop_config.yml
+++ b/config/forced_rubocop_config.yml
@@ -122,6 +122,15 @@ Style/FrozenStringLiteralComment:
 Style/IfUnlessModifier:
   AutoCorrect: false
 
+<% if rubocop_version >= '1.37.0' %>
+# This new cop can trigger on the here-doc we use for filters that contain interpolation.
+# Ex:
+# :javascript
+#   hello #{world} \. bad escape
+Style/RedundantStringEscape:
+  Enabled: false
+<% end %>
+
 # In some case, this cop can cause a change in the spacing.
 # In HAML 5.2, going from (absurd example for clarity):
 #   = 'abc' rescue nil

--- a/spec/haml_lint/linter/rubocop_autocorrect_examples/.rubocop.yml
+++ b/spec/haml_lint/linter/rubocop_autocorrect_examples/.rubocop.yml
@@ -1,2 +1,9 @@
 # Just an empty rubocop config so that examples are based on the default rubocop config
 # instead of this project's personal config
+
+# This new cop can trigger on the here-doc we use for filters that contain interpolation.
+# Activating it here, but it's also disabled in config/forced_rubocop_config.yml
+# Because this cop was added in '1.37.0', we can't enable it all the time for now, or tests will fail
+# So this is used to easily uncomment them when testing manually
+#Style/RedundantStringEscape:
+#  Enabled: true

--- a/spec/haml_lint/linter/rubocop_autocorrect_examples/interpolation_examples.txt
+++ b/spec/haml_lint/linter/rubocop_autocorrect_examples/interpolation_examples.txt
@@ -1160,3 +1160,23 @@ ensure
 end
 ---
 %tag&== hello #{foo(bar: 123)} world
+
+
+!!! fixes non-ruby filter's interpolations that has unusual escape sequence gfds
+:filter
+  Dolor #{foo(:bar =>  123)} and a unusual escape \. that is acceptable in a filter
+---
+haml_lint_marker_1
+HL.out = <<~HAML_LINT_FILTER
+  Dolor #{foo(:bar =>  123)} and a unusual escape \. that is acceptable in a filter$$$2
+HAML_LINT_FILTER
+haml_lint_marker_5
+---
+haml_lint_marker_1
+HL.out = <<~HAML_LINT_FILTER
+  Dolor #{foo(bar: 123)} and a unusual escape \. that is acceptable in a filter
+HAML_LINT_FILTER
+haml_lint_marker_5
+---
+:filter
+  Dolor #{foo(bar: 123)} and a unusual escape \. that is acceptable in a filter

--- a/spec/haml_lint/linter/rubocop_autocorrect_examples/placeholder_examples.txt
+++ b/spec/haml_lint/linter/rubocop_autocorrect_examples/placeholder_examples.txt
@@ -80,3 +80,15 @@ haml_lint_plain_1
 haml_lint_plain_1
 ---
 &== Lorem Ipsum
+
+
+!!! Has a placeholder for filter with no interpolation and a string escape
+:filter
+  Lorem Ipsum \. doesn't need the backslash
+---
+haml_lint_filter_1
+---
+haml_lint_filter_1
+---
+:filter
+  Lorem Ipsum \. doesn't need the backslash


### PR DESCRIPTION
It interacts poorly with the here-docs we use for filters with interpolation

Closes #438