### PR TITLE
Cut version 0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HAML-Lint Changelog
 
+### 0.50.0
+
+* Update minimum Ruby version to 2.7+
+* Disable RuboCop's `Style/RedundantStringEscape` cop
+
 ### 0.49.3
 
 * Fix some cases where part of multiline scripts could end up less indented than the

--- a/lib/haml_lint/version.rb
+++ b/lib/haml_lint/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 module HamlLint
-  VERSION = '0.49.3'
+  VERSION = '0.50.0'
 end


### PR DESCRIPTION
* Update minimum Ruby version to 2.7+
* Disable RuboCop's `Style/RedundantStringEscape` cop