### PR TITLE
Fix markdown highlighting in linter readme

### DIFF
--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -281,7 +281,7 @@ preferred styles, `lisp_case` (default), `camel_case`, `pascal_case`, or
 #PascalCase
 ```
 
-**With `snake_case` style option: require ids in snake_case_format*
+**With `snake_case` style option: require ids in snake_case_format**
 ```haml
 #snake_case
 %div{ id: 'snake_case' }


### PR DESCRIPTION
Trailing asterisk was missing, leading to incorrect bolding of the snake_case rule description in the IdNames section.