### PR TITLE
Add `--stderr` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Command Line Flag          | Description
 `--[no-]summary`           | Whether to output a summary in the default reporter
 `--show-linters`           | Show all registered linters
 `--show-reporters`         | Display available reporters
+`--stderr`                 | Write all output to stderr
 `-h`/`--help`              | Show command line flag documentation
 `-v`/`--version`           | Show `haml-lint` version
 `-V`/`--verbose-version`   | Show `haml-lint`, `haml`, and `ruby` version information

--- a/bin/haml-lint
+++ b/bin/haml-lint
@@ -4,5 +4,4 @@
 require 'haml_lint'
 require 'haml_lint/cli'
 
-logger = HamlLint::Logger.new($stdout)
-exit HamlLint::CLI.new(logger).run(ARGV)
+exit HamlLint::CLI.new.run(ARGV)

--- a/lib/haml_lint/cli.rb
+++ b/lib/haml_lint/cli.rb
@@ -10,8 +10,8 @@ module HamlLint
   class CLI
     # Create a CLI that outputs to the specified logger.
     #
-    # @param logger [HamlLint::Logger]
-    def initialize(logger)
+    # @param logger [HamlLint::Logger, nil]
+    def initialize(logger = nil)
       @log = logger
     end
 
@@ -63,6 +63,7 @@ module HamlLint
     #
     # @return [void]
     def configure_logger(options)
+      @log ||= HamlLint::Logger.new(options[:stderr] ? $stderr : $stdout)
       log.color_enabled = options.fetch(:color, log.tty?)
       log.summary_enabled = options.fetch(:summary, true)
     end

--- a/lib/haml_lint/options.rb
+++ b/lib/haml_lint/options.rb
@@ -69,6 +69,10 @@ module HamlLint
         @options[:autocorrect_only] = true
         @options[:autocorrect] ||= :safe
       end
+
+      parser.on('--stderr', 'Write all output to stderr') do
+        @options[:stderr] = true
+      end
     end
 
     def add_report_options(parser)

--- a/lib/haml_lint/rake_task.rb
+++ b/lib/haml_lint/rake_task.rb
@@ -104,7 +104,7 @@ module HamlLint
     # @param task_args [Rake::TaskArguments]
     def run_cli(task_args)
       cli_args = parse_args
-      logger = quiet ? HamlLint::Logger.silent : HamlLint::Logger.new($stdout)
+      logger = quiet ? HamlLint::Logger.silent : nil
       result = HamlLint::CLI.new(logger).run(Array(cli_args) + files_to_lint(task_args))
 
       fail "#{HamlLint::APP_NAME} failed with exit code #{result}" unless result == 0

--- a/spec/haml_lint/cli_spec.rb
+++ b/spec/haml_lint/cli_spec.rb
@@ -38,6 +38,27 @@ describe HamlLint::CLI do
       end
     end
 
+    context 'when a logger is not passed' do
+      let(:logger) { nil }
+
+      it 'sets a default logger that writes to stdout' do
+        $stdout = StringIO.new
+        subject
+        expect(cli.send(:log).instance_variable_get(:'@out')).to eq($stdout)
+      end
+    end
+
+    context 'when passed the --stderr flag' do
+      let(:logger) { nil }
+      let(:args) { %w[--stderr] }
+
+      it 'sets a logger that writes to stderr' do
+        $stderr = StringIO.new
+        subject
+        expect(cli.send(:log).instance_variable_get(:'@out')).to eq($stderr)
+      end
+    end
+
     context 'when passed the --color flag' do
       let(:args) { ['--color'] }
 

--- a/spec/haml_lint/options_spec.rb
+++ b/spec/haml_lint/options_spec.rb
@@ -157,6 +157,14 @@ describe HamlLint::Options do
       end
     end
 
+    context 'with --stderr' do
+      let(:args) { %w[--stderr] }
+
+      it 'sets the stderr option to true' do
+        subject[:stderr].should == true
+      end
+    end
+
     context 'fail fast' do
       let(:args) { %w[--fail-fast] }
 


### PR DESCRIPTION
As suggested by @MaxLap on #452 

This option can stand on its own and is pretty straightforward (just need to point the logger to `$stderr` I believe), so I figured I would implement it before I work out `--stdin`.