### PR TITLE
Make node_for_line return the last possible node when nothing matches

### DIFF
--- a/lib/haml_lint/tree/root_node.rb
+++ b/lib/haml_lint/tree/root_node.rb
@@ -16,10 +16,26 @@ module HamlLint::Tree
     #
     # @param line [Integer] the line number of the node
     # @return [HamlLint::Node]
-    def node_for_line(line)
-      find(-> { HamlLint::Tree::NullNode.new }) do |node|
-        node.line_numbers.cover?(line) && node != self
+    def node_for_line(line) # rubocop:disable Metrics
+      each do |node|
+        return node if node.line_numbers.cover?(line) && node != self
       end
+
+      # Because HAML doesn't leave any trace in the nodes when it merges lines that
+      # end with a comma, it's harder to assign a node to the second line here:
+      # = some_call user,
+      #             foo, bar
+      # So if the simple strategy (above) doesn't work, we try to see if we check if the last node
+      # that was before the requested line was one that could have been merged. If so, we use that one.
+      best_guess = nil
+      each do |node|
+        best_guess = node if node != self && node.line_numbers.end < line
+      end
+
+      # There are the cases were the merging without traces can happen
+      return best_guess if best_guess && %i[script silent_script tag].include?(best_guess.type)
+
+      HamlLint::Tree::NullNode.new
     end
   end
 end

--- a/spec/haml_lint/linter/line_length_spec.rb
+++ b/spec/haml_lint/linter/line_length_spec.rb
@@ -75,4 +75,17 @@ describe HamlLint::Linter::LineLength do
 
     it { should_not report_lint }
   end
+
+  context 'when there is a directive before a long line that is a continued line' do
+    let(:haml) do
+      <<-HAML
+        -# haml-lint:disable LineLength
+        = link_to user,
+          class: some_unfortunately_very_extremely_definitely_over_90_characters_helper_method_with_even_more_characters
+        -# haml-lint:enable LineLength
+      HAML
+    end
+
+    it { should_not report_lint }
+  end
 end


### PR DESCRIPTION
Bitten by HAML's parser anoying behavior of just merging lines into one without leaving any trace!

I fixed a problem in `line_numbers` when I made the RuboCop refactor, so the line count was more accurate. But that highlighted the lack of handling for multiline scripts in that method.

I'm patching `node_for_line` because managing to make line_numbers more accurate would require quite a bit of monkey-patching or probably mean a performance hit for something that is quite rarely needed.

Fixes #451