### PR TITLE
Fix a spec that broke because of a change in rubocop

### DIFF
--- a/spec/haml_lint/linter/rubocop_autocorrect_examples/script_examples.txt
+++ b/spec/haml_lint/linter/rubocop_autocorrect_examples/script_examples.txt
@@ -462,22 +462,22 @@ haml_lint_marker_9
 
 
 !!! Handles an anonymous block with a trailing comment
-- list.each do |var, var2| # Some comment
+- list.each do |var| # Some comment
   = foo(:bar =>  123)
 ---
 haml_lint_marker_1
-list.each do |var, var2| # Some comment
+list.each do |var| # Some comment
   HL.out = foo(:bar =>  123) $$2
 end
 haml_lint_marker_5
 ---
 haml_lint_marker_1
-list.each do |_var, _var2| # Some comment
+list.each do |_var| # Some comment
   HL.out = foo(bar: 123)
 end
 haml_lint_marker_5
 ---
-- list.each do |_var, _var2| # Some comment
+- list.each do |_var| # Some comment
   = foo(bar: 123)
 
 


### PR DESCRIPTION
Locally, my specs had an error and so did the reporter of #464.

CI probably doesn't have the exact same version of RuboCop.

Fixes #464