### PR TITLE
Drop support for Ruby 2.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - "2.7"
           - "3.0"
           - "3.1"
           - "3.2"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   Exclude:
     - 'gemfiles/**'
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.0
   NewCops: disable
 
 Lint/AssignmentInCondition:

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ your [SCM hooks](https://github.com/sds/overcommit).
 
 ## Requirements
 
- * Ruby 2.6+
- * HAML 4.0+
+ * Ruby 3+
+ * HAML 5.0+
 
 ## Installation
 

--- a/haml_lint.gemspec
+++ b/haml_lint.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.files            = Dir['config/**.yml'] +
                        Dir['lib/**/*.rb']
 
-  s.required_ruby_version = '>= 2.7.0'
+  s.required_ruby_version = '>= 3.0'
 
   s.add_dependency 'haml', '>= 5.0'
   s.add_dependency 'parallel', '~> 1.10'

--- a/lib/haml_lint/constants.rb
+++ b/lib/haml_lint/constants.rb
@@ -6,5 +6,5 @@ module HamlLint
   APP_NAME = 'haml-lint'
 
   REPO_URL = 'https://github.com/sds/haml-lint'
-  BUG_REPORT_URL = "#{REPO_URL}/issues"
+  BUG_REPORT_URL = "#{REPO_URL}/issues".freeze
 end

--- a/lib/haml_lint/directive.rb
+++ b/lib/haml_lint/directive.rb
@@ -3,7 +3,7 @@
 module HamlLint
   # Handles linter configuration transformation via Haml comments.
   class Directive
-    LINTER_REGEXP = /(?:[A-Z]\w+)/.freeze
+    LINTER_REGEXP = /(?:[A-Z]\w+)/
 
     DIRECTIVE_REGEXP = /
       # "haml-lint:" with optional spacing
@@ -14,7 +14,7 @@ module HamlLint
 
       # "all" or a comma-separated list (with optional spaces) of linters
       (?<linters>all | (?:#{LINTER_REGEXP}\s*,\s*)* #{LINTER_REGEXP})
-    /x.freeze
+    /x
 
     # Constructs a directive from source code as a given line.
     #

--- a/lib/haml_lint/linter/alignment_tabs.rb
+++ b/lib/haml_lint/linter/alignment_tabs.rb
@@ -3,7 +3,7 @@
 module HamlLint
   # Checks for tabs that are placed for alignment of tag content
   class Linter::AlignmentTabs < Linter
-    REGEX = /[^\s*]\t+/.freeze
+    REGEX = /[^\s*]\t+/
 
     def visit_tag(node)
       if REGEX.match?(node.source_code)

--- a/lib/haml_lint/linter/class_attribute_with_static_value.rb
+++ b/lib/haml_lint/linter/class_attribute_with_static_value.rb
@@ -20,7 +20,7 @@ module HamlLint
 
     STATIC_TYPES = %i[str sym].freeze
 
-    VALID_CLASS_REGEX = /^-?[_a-zA-Z]+[_a-zA-Z0-9-]*$/.freeze
+    VALID_CLASS_REGEX = /^-?[_a-zA-Z]+[_a-zA-Z0-9-]*$/
 
     def visit_tag(node)
       return unless contains_class_attribute?(node.dynamic_attributes_sources)

--- a/lib/haml_lint/linter/indentation.rb
+++ b/lib/haml_lint/linter/indentation.rb
@@ -11,7 +11,7 @@ module HamlLint
       tab: /^\t*(?! )/,
     }.freeze
 
-    LEADING_SPACES_REGEX = /^( +)(?! )/.freeze
+    LEADING_SPACES_REGEX = /^( +)(?! )/
 
     def visit_root(root)
       character = config['character'].to_sym

--- a/lib/haml_lint/linter/multiline_pipe.rb
+++ b/lib/haml_lint/linter/multiline_pipe.rb
@@ -31,7 +31,7 @@ module HamlLint
 
     private
 
-    MULTILINE_PIPE_REGEX = /\s+\|\s*$/.freeze
+    MULTILINE_PIPE_REGEX = /\s+\|\s*$/
 
     def line_text_for_node(node)
       document.source_lines[node.line - 1]

--- a/lib/haml_lint/linter/no_placeholders.rb
+++ b/lib/haml_lint/linter/no_placeholders.rb
@@ -6,8 +6,8 @@ module HamlLint
     include LinterRegistry
 
     MSG = 'Placeholders attributes should not be used.'
-    HASH_REGEXP = /:?['"]?placeholder['"]?(?::| *=>)/.freeze
-    HTML_REGEXP = /placeholder=/.freeze
+    HASH_REGEXP = /:?['"]?placeholder['"]?(?::| *=>)/
+    HTML_REGEXP = /placeholder=/
 
     def visit_tag(node)
       return unless node.hash_attributes_source =~ HASH_REGEXP || node.html_attributes_source =~ HTML_REGEXP


### PR DESCRIPTION
Ruby 2.7 reached EoL in March 2023. Stop supporting it.
