### PR TITLE
Add `-s`/`--stdin` option

### DIFF
--- a/lib/haml_lint/document.rb
+++ b/lib/haml_lint/document.rb
@@ -14,7 +14,7 @@ module HamlLint
     # @return [String] Haml template file path
     attr_reader :file
 
-    # @return [true, false] Write source changes to stdout instead of disk
+    # @return [Boolean] true if source changes (from autocorrect) should be written to stdout instead of disk
     attr_reader :write_to_stdout
 
     # @return [HamlLint::Tree::Node] Root of the parse tree
@@ -39,6 +39,7 @@ module HamlLint
     # @param source [String] Haml code to parse
     # @param options [Hash]
     # @option options :file [String] file name of document that was parsed
+    # @option options :write_to_stdout [Boolean] true if source changes should be written to stdout
     # @raise [Haml::Parser::Error] if there was a problem parsing the document
     def initialize(source, options)
       @config = options[:config]

--- a/lib/haml_lint/document.rb
+++ b/lib/haml_lint/document.rb
@@ -14,6 +14,9 @@ module HamlLint
     # @return [String] Haml template file path
     attr_reader :file
 
+    # @return [true, false] Write source changes to stdout instead of disk
+    attr_reader :write_to_stdout
+
     # @return [HamlLint::Tree::Node] Root of the parse tree
     attr_reader :tree
 
@@ -40,6 +43,7 @@ module HamlLint
     def initialize(source, options)
       @config = options[:config]
       @file = options.fetch(:file, STRING_SOURCE)
+      @write_to_stdout = options[:write_to_stdout]
       @source_was_changed = false
       process_source(source)
     end
@@ -82,7 +86,11 @@ module HamlLint
       if file == STRING_SOURCE
         raise HamlLint::Exceptions::InvalidFilePath, 'Cannot write without :file option'
       end
-      File.write(file, unstrip_frontmatter(source))
+      if @write_to_stdout
+        $stdout << unstrip_frontmatter(source)
+      else
+        File.write(file, unstrip_frontmatter(source))
+      end
       @source_was_changed = false
     end
 

--- a/lib/haml_lint/options.rb
+++ b/lib/haml_lint/options.rb
@@ -70,7 +70,13 @@ module HamlLint
         @options[:autocorrect] ||= :safe
       end
 
-      parser.on('--stderr', 'Write all output to stderr') do
+      parser.on('-s', '--stdin FILE', 'Pipe source from STDIN, using FILE in ' \
+          'offense when combined with --auto-correct and --stdin.') do |file_path|
+        @options[:stdin] = file_path
+      end
+
+      parser.on('--stderr', 'Write all output to stderr except for the autocorrected source. ' \
+          'This is especially useful when combined with --auto-correct and --stdin') do
         @options[:stderr] = true
       end
     end

--- a/lib/haml_lint/options.rb
+++ b/lib/haml_lint/options.rb
@@ -32,7 +32,7 @@ module HamlLint
 
     private
 
-    def add_linter_options(parser) # rubocop:disable Metrics/MethodLength
+    def add_linter_options(parser) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       parser.on('--auto-gen-config', 'Generate a configuration file acting as a TODO list') do
         @options[:auto_gen_config] = true
       end

--- a/lib/haml_lint/source.rb
+++ b/lib/haml_lint/source.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module HamlLint
+  # Wrapper class representing a single target for HamlLint::Runner to run against, comprised of an IO object
+  # containing haml code, as well as a file path.
+  class Source
+    # @return [String] File path associated with the given IO object.
+    attr_reader :path
+
+    # Wraps an IO object and file path to a source object.
+    #
+    # @param [IO] io
+    # @param [String] path
+    def initialize(io, path)
+      @io = io
+      @path = path
+    end
+
+    # @return [String] Contents of the given IO object.
+    def contents
+      @contents ||= @io.read
+    end
+  end
+end

--- a/spec/haml_lint/options_spec.rb
+++ b/spec/haml_lint/options_spec.rb
@@ -157,6 +157,22 @@ describe HamlLint::Options do
       end
     end
 
+    context 'with -s' do
+      let(:args) { %w[-s path] }
+
+      it 'sets the stdin option to the given file path' do
+        subject[:stdin].should == 'path'
+      end
+    end
+
+    context 'with --stdin' do
+      let(:args) { %w[--stdin path] }
+
+      it 'sets the stdin option to the given file path' do
+        subject[:stdin].should == 'path'
+      end
+    end
+
     context 'with --stderr' do
       let(:args) { %w[--stderr] }
 

--- a/spec/haml_lint/runner_spec.rb
+++ b/spec/haml_lint/runner_spec.rb
@@ -178,5 +178,22 @@ describe HamlLint::Runner do
         subject.lints.first.message.should match(/Prefer single-quoted strings/)
       end
     end
+
+    context 'with the stdin option, stderr option and autocorrect option' do
+      let(:options) { base_options.merge(stdin: 'test.html.haml', stderr: true, autocorrect: :safe) }
+      let(:stdin) { +"= \"Single-quoted strings offense\".capitalize\n" }
+
+      before do
+        $stdin.stub(:read).and_return(stdin)
+        $stdout.stub(:write).and_return(nil)
+      end
+
+      it 'lints input from stdin using the given file name and writes autocorrect results to stdout' do
+        subject.lints.size.should == 1
+        subject.lints.first.filename.should == 'test.html.haml'
+        subject.lints.first.message.should match(/Prefer single-quoted strings/)
+        $stdout.should have_received(:write).with("= 'Single-quoted strings offense'.capitalize\n")
+      end
+    end
   end
 end

--- a/spec/haml_lint/runner_spec.rb
+++ b/spec/haml_lint/runner_spec.rb
@@ -167,5 +167,18 @@ describe HamlLint::Runner do
         end
       end
     end
+
+    context 'with the stdin option' do
+      let(:options) { base_options.merge(stdin: 'test.html.haml') }
+      let(:stdin) { +"= \"Single-quoted strings offense\".capitalize\n" }
+
+      before { $stdin.stub(:read).and_return(stdin) }
+
+      it 'lints input from stdin using the given file name' do
+        subject.lints.size.should == 1
+        subject.lints.first.filename.should == 'test.html.haml'
+        subject.lints.first.message.should match(/Prefer single-quoted strings/)
+      end
+    end
   end
 end

--- a/spec/haml_lint/runner_spec.rb
+++ b/spec/haml_lint/runner_spec.rb
@@ -91,8 +91,6 @@ describe HamlLint::Runner do
         end
 
         context 'when errors are present' do
-
-
           it 'successfully reports those errors' do
             expect(subject.lints.first.message).to match(/Avoid defining `class` in attributes hash/)
           end


### PR DESCRIPTION
Closes #452

It's been a while, but finally had some bandwidth to write this out. As laid out in the issue, implements `-s`/`--stdin` to mirror the corresponding `rubocop` options.

The biggest obstacle was separating a source file's contents from its path in the context of `HamlLint::Runner`. I achieved that here by adding a lightweight wrapper class `HamlLint::Source` that accepts an IO object and path string separately, the former allowing for easy interchange between `StringIO` (from stdin) and `File` (from normal execution) objects.

I initially was passing around hashes (i.e. `{ io: ..., path: ... }`) but settled on a class as it's a bit more elegant and way nicer to document. I can also see the `Source` class taking on a little more repsonsibility with future refactoring as well (move `extract_applicable_files/sources` to a class method there, pass it directly to `Document`, etc).

Anyways, beyond that it was just little tweaks to get specs/autocorrect to play nice with the new abstraction/option respectively.