### PR TITLE
Fix `block_keyword` method returning keywords used as arguments of method call

### DIFF
--- a/lib/haml_lint/ruby_extraction/chunk_extractor.rb
+++ b/lib/haml_lint/ruby_extraction/chunk_extractor.rb
@@ -692,7 +692,7 @@ module HamlLint::RubyExtraction
         return keyword
       end
 
-      code.scan(Haml::Parser::BLOCK_KEYWORD_REGEX) do |c|
+      code.scan(Haml::Parser::BLOCK_KEYWORD_REGEX) do |_c|
         # Check that the keyword is actually a keyword, and not
         # an argument to a method.
         next_char = code[Regexp.last_match.offset(0)[1]]
@@ -702,7 +702,7 @@ module HamlLint::RubyExtraction
         return Regexp.last_match[1] || Regexp.last_match[2]
       end
 
-      return nil
+      nil
     end
   end
 end

--- a/lib/haml_lint/ruby_extraction/chunk_extractor.rb
+++ b/lib/haml_lint/ruby_extraction/chunk_extractor.rb
@@ -692,8 +692,17 @@ module HamlLint::RubyExtraction
         return keyword
       end
 
-      return unless keyword = code.scan(Haml::Parser::BLOCK_KEYWORD_REGEX)[0]
-      keyword[0] || keyword[1]
+      code.scan(Haml::Parser::BLOCK_KEYWORD_REGEX) do |c|
+        # Check that the keyword is actually a keyword, and not
+        # an argument to a method.
+        next_char = code[Regexp.last_match.offset(0)[1]]
+
+        next if next_char == ':'
+
+        return Regexp.last_match[1] || Regexp.last_match[2]
+      end
+
+      return nil
     end
   end
 end

--- a/spec/haml_lint/ruby_extraction/chunk_extractor_spec.rb
+++ b/spec/haml_lint/ruby_extraction/chunk_extractor_spec.rb
@@ -261,25 +261,25 @@ describe HamlLint::RubyExtraction::ChunkExtractor do
       expect(described_class.block_keyword(input_single_line)).to eq(nil)
 
       # Keyword as symbol not first on new line should work
-      input_multiline_1 = <<~HAML
+      input_multiline1 = <<~HAML
         = helper foo: true,
                  bar: true, if: false
       HAML
-      expect(described_class.block_keyword(input_multiline_1)).to eq(nil)
+      expect(described_class.block_keyword(input_multiline1)).to eq(nil)
 
       # Keyword as symbol first on new line should also work
-      input_multiline_2 = <<~HAML
+      input_multiline2 = <<~HAML
         = helper foo: true, bar: true,
                  if: false
       HAML
-      expect(described_class.block_keyword(input_multiline_2)).to eq(nil)
+      expect(described_class.block_keyword(input_multiline2)).to eq(nil)
 
       # Testing with another keyword
-      input_multiline_3 = <<~HAML
+      input_multiline3 = <<~HAML
         = helper foo: true, bar: true,
                  for: User.first
       HAML
-      expect(described_class.block_keyword(input_multiline_3)).to eq(nil)
+      expect(described_class.block_keyword(input_multiline3)).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
Hey there

I noticed a bug when using one of the keywords used by `HamlLint::RubyExtraction::ChunkExtractor.block_keyword` is used as a keyword argument, e.g. for a helper method (i.e. as a symbol).

The following works without any issues:

```ruby
= helper foo: true, bar: true, if: false
```

as well as

```ruby
= helper foo: true,
         bar: true, if: false
```

However, the following code will produce an exception:

```ruby
= helper foo: true, bar: true,
         if: false
```

This is also the case for other keywords, e.g. `unless`:

```ruby
= helper foo: true, bar: true,
         unless: User.first
```

Whether using such Ruby keywords as keyword arguments is a sensible idea is another question, however the last 2 examples will produce the following exception:

```bash
RuboCop: Couldn't process the file for linting. RuntimeError: Line <lineno> should be followed by indentation. This might actually work in Haml, but it's almost a bug that it does. haml-lint cannot process.
```

The code works perfectly fine in HAML, so I guess it should also be accepted by haml-lint.

I adapted the `HamlLint::RubyExtraction::ChunkExtractor.block_keyword` method to ignore such "keyword argument" occurences of keywords, and added some testcases. Feel free to suggest edits, otherwise thanks for looking at this PR.

Have a nice day