### PR TITLE
Fix typos

### DIFF
--- a/lib/haml_lint/extensions/haml_util_unescape_interpolation_tracking.rb
+++ b/lib/haml_lint/extensions/haml_util_unescape_interpolation_tracking.rb
@@ -14,7 +14,7 @@ module Haml::Util
     Thread.current[:haml_lint_unescape_interpolation_to_original_cache] ||= {}
   end
 
-  # As soon as a HamlLint::Document has finished processing a HAML souce, this gets called to
+  # As soon as a HamlLint::Document has finished processing a HAML source, this gets called to
   # get a copy of this cache and clear up for the next HAML processing
   def self.unescape_interpolation_to_original_cache_take_and_wipe
     value = unescape_interpolation_to_original_cache.dup

--- a/lib/haml_lint/linter/rubocop.rb
+++ b/lib/haml_lint/linter/rubocop.rb
@@ -117,7 +117,7 @@ module HamlLint
         # so the lints will be recorded then.
         @lints = []
 
-        msg = "Corrections couldn't be transfered: #{e.message} - Consider linting the file " \
+        msg = "Corrections couldn't be transferred: #{e.message} - Consider linting the file " \
               'without auto-correct and doing the changes manually.'
         if ENV['HAML_LINT_DEBUG'] == 'true'
           msg = "#{msg} DEBUG: Rubocop corrected Ruby code follows:\n#{new_ruby_code}\n------"

--- a/lib/haml_lint/reporter/utils.rb
+++ b/lib/haml_lint/reporter/utils.rb
@@ -96,7 +96,7 @@ module HamlLint
       # Prints a summary of the number of lints found in a report.
       #
       # @param report [HamlLint::Report] the report to print
-      # @param is_append [Boolean] if this is appending to a line. Will preffix with ", ".
+      # @param is_append [Boolean] if this is appending to a line. Will prefix with ", ".
       # @return [void]
       def print_summary_lints(report, is_append:)
         log.log ', ', false if is_append
@@ -114,7 +114,7 @@ module HamlLint
       # Prints a summary of the number of lints corrected in a report.
       #
       # @param report [HamlLint::Report] the report to print
-      # @param is_append [Boolean] if this is appending to a line. Will preffix with ", ".
+      # @param is_append [Boolean] if this is appending to a line. Will prefix with ", ".
       # @return [void]
       def print_summary_corrected_lints(report, is_append:)
         lint_count = report.lints.count(&:corrected)

--- a/lib/haml_lint/ruby_extraction/base_chunk.rb
+++ b/lib/haml_lint/ruby_extraction/base_chunk.rb
@@ -63,7 +63,7 @@ module HamlLint::RubyExtraction
       transfer_correction_logic(coordinator, to_ruby_lines, haml_lines)
     end
 
-    # To be overriden by subclasses.
+    # To be overridden by subclasses.
     #
     # Logic to transfer the corrections that turned from_ruby_lines into to_ruby_lines.
     #

--- a/lib/haml_lint/ruby_extraction/chunk_extractor.rb
+++ b/lib/haml_lint/ruby_extraction/chunk_extractor.rb
@@ -678,7 +678,7 @@ module HamlLint::RubyExtraction
 
     def self.anonymous_block?(code)
       # Don't start with a comment and end with a `do`
-      # Definetly not perfect for the comment handling, but otherwise a more advanced parsing system is needed.
+      # Definitely not perfect for the comment handling, but otherwise a more advanced parsing system is needed.
       # Move the comment to its own line if it's annoying.
       code !~ /\A\s*#/ &&
         code =~ /\bdo\s*(\|[^|]*\|\s*)?(#.*)?\z/

--- a/lib/haml_lint/tree/root_node.rb
+++ b/lib/haml_lint/tree/root_node.rb
@@ -5,7 +5,7 @@ require 'haml_lint/tree/null_node'
 module HamlLint::Tree
   # Represents the root node of a HAML document that contains all other nodes.
   class RootNode < Node
-    # The name fo the file parsed to build this tree.
+    # The name of the file parsed to build this tree.
     #
     # @return [String] a file name
     def file

--- a/lib/haml_lint/utils.rb
+++ b/lib/haml_lint/utils.rb
@@ -116,7 +116,7 @@ module HamlLint
 
     # Returns indexes of all occurrences of a substring within a string.
     #
-    # Note, this will not return overlaping substrings, so searching for "aa"
+    # Note, this will not return overlapping substrings, so searching for "aa"
     # in "aaa" will only find one substring, not two.
     #
     # @param text [String] the text to search

--- a/spec/haml_lint/document_spec.rb
+++ b/spec/haml_lint/document_spec.rb
@@ -88,7 +88,7 @@ describe HamlLint::Document do
       end
     end
 
-    context 'when source is valid UTF-8 but was interpeted as US-ASCII' do
+    context 'when source is valid UTF-8 but was interpreted as US-ASCII' do
       let(:source) { '%p Test àéùö'.force_encoding('US-ASCII') }
 
       it 'interprets it as UTF-8' do


### PR DESCRIPTION
```
codespell **/*.rb -L filetest,compliancy,reenable -w
```

Plus a manual fix of

```
lib/haml_lint/tree/root_node.rb:8: fo ==> of, for, to, do, go
```