### PR TITLE
Prefer `require_relative` for internal requires

### DIFF
--- a/lib/haml_lint.rb
+++ b/lib/haml_lint.rb
@@ -3,26 +3,26 @@
 # Need to load haml before we can reference some Haml modules in our code
 require 'haml'
 
-require 'haml_lint/constants'
-require 'haml_lint/exceptions'
-require 'haml_lint/configuration'
-require 'haml_lint/configuration_loader'
-require 'haml_lint/document'
-require 'haml_lint/haml_visitor'
-require 'haml_lint/lint'
-require 'haml_lint/linter_registry'
-require 'haml_lint/ruby_parser'
-require 'haml_lint/linter'
-require 'haml_lint/logger'
-require 'haml_lint/reporter'
-require 'haml_lint/report'
-require 'haml_lint/linter_selector'
-require 'haml_lint/file_finder'
-require 'haml_lint/runner'
-require 'haml_lint/utils'
-require 'haml_lint/version'
-require 'haml_lint/version_comparer'
-require 'haml_lint/severity'
+require_relative 'haml_lint/constants'
+require_relative 'haml_lint/exceptions'
+require_relative 'haml_lint/configuration'
+require_relative 'haml_lint/configuration_loader'
+require_relative 'haml_lint/document'
+require_relative 'haml_lint/haml_visitor'
+require_relative 'haml_lint/lint'
+require_relative 'haml_lint/linter_registry'
+require_relative 'haml_lint/ruby_parser'
+require_relative 'haml_lint/linter'
+require_relative 'haml_lint/logger'
+require_relative 'haml_lint/reporter'
+require_relative 'haml_lint/report'
+require_relative 'haml_lint/linter_selector'
+require_relative 'haml_lint/file_finder'
+require_relative 'haml_lint/runner'
+require_relative 'haml_lint/utils'
+require_relative 'haml_lint/version'
+require_relative 'haml_lint/version_comparer'
+require_relative 'haml_lint/severity'
 
 # Lead all extensions to external source code
 Dir[File.expand_path('haml_lint/extensions/*.rb', File.dirname(__FILE__))].sort.each do |file|
@@ -30,8 +30,8 @@ Dir[File.expand_path('haml_lint/extensions/*.rb', File.dirname(__FILE__))].sort.
 end
 
 # Load all parse tree node classes
-require 'haml_lint/tree/node'
-require 'haml_lint/node_transformer'
+require_relative 'haml_lint/tree/node'
+require_relative 'haml_lint/node_transformer'
 Dir[File.expand_path('haml_lint/tree/*.rb', File.dirname(__FILE__))].sort.each do |file|
   require file
 end
@@ -47,7 +47,7 @@ Dir[File.expand_path('haml_lint/reporter/*.rb', File.dirname(__FILE__))].sort.ea
 end
 
 # Load all the chunks for RubyExtraction
-require 'haml_lint/ruby_extraction/base_chunk'
+require_relative 'haml_lint/ruby_extraction/base_chunk'
 Dir[File.expand_path('haml_lint/ruby_extraction/*.rb', File.dirname(__FILE__))].sort.each do |file|
   require file
 end

--- a/lib/haml_lint/adapter.rb
+++ b/lib/haml_lint/adapter.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'haml_lint/adapter/haml_5'
-require 'haml_lint/adapter/haml_6'
-require 'haml_lint/exceptions'
+require_relative 'adapter/haml_5'
+require_relative 'adapter/haml_6'
+require_relative 'exceptions'
 
 module HamlLint
   # Determines the adapter to use for the current Haml version

--- a/lib/haml_lint/cli.rb
+++ b/lib/haml_lint/cli.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'haml_lint'
-require 'haml_lint/options'
+require_relative '../haml_lint'
+require_relative 'options'
 
 require 'sysexits'
 

--- a/lib/haml_lint/document.rb
+++ b/lib/haml_lint/document.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'haml_lint/adapter'
+require_relative 'adapter'
 
 module HamlLint
   # Represents a parsed Haml document and its associated metadata.

--- a/lib/haml_lint/rake_task.rb
+++ b/lib/haml_lint/rake_task.rb
@@ -2,7 +2,8 @@
 
 require 'rake'
 require 'rake/tasklib'
-require 'haml_lint/constants'
+
+require_relative 'constants'
 
 module HamlLint
   # Rake task interface for haml-lint command line interface.
@@ -93,7 +94,7 @@ module HamlLint
 
       task(name, [:files]) do |_task, task_args|
         # Lazy-load so task doesn't affect Rakefile load time
-        require 'haml_lint/cli'
+        require_relative 'cli'
 
         run_cli(task_args)
       end

--- a/lib/haml_lint/reporter.rb
+++ b/lib/haml_lint/reporter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'haml_lint/reporter/hooks'
+require_relative 'reporter/hooks'
 
 module HamlLint
   # Abstract lint reporter. Subclass and override {#display_report} to

--- a/lib/haml_lint/reporter/default_reporter.rb
+++ b/lib/haml_lint/reporter/default_reporter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'haml_lint/reporter/utils'
+require_relative 'utils'
 
 module HamlLint
   # Outputs lints in a simple format with the filename, line number, and lint

--- a/lib/haml_lint/reporter/disabled_config_reporter.rb
+++ b/lib/haml_lint/reporter/disabled_config_reporter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'haml_lint/reporter/progress_reporter'
+require_relative 'progress_reporter'
 
 module HamlLint
   # Outputs a YAML configuration file based on existing violations.

--- a/lib/haml_lint/reporter/json_reporter.rb
+++ b/lib/haml_lint/reporter/json_reporter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'haml_lint/reporter/hash_reporter'
+require_relative 'hash_reporter'
 
 module HamlLint
   # Outputs report as a JSON document.

--- a/lib/haml_lint/reporter/progress_reporter.rb
+++ b/lib/haml_lint/reporter/progress_reporter.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require 'rainbow'
-require 'haml_lint/reporter/utils'
+
+require_relative 'utils'
 
 module HamlLint
   # Outputs files as they are output as a simple symbol, then outputs

--- a/lib/haml_lint/runner.rb
+++ b/lib/haml_lint/runner.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'parallel'
+
 require_relative 'source'
 
 module HamlLint

--- a/lib/haml_lint/spec.rb
+++ b/lib/haml_lint/spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'haml_lint/spec/normalize_indent'
-require 'haml_lint/spec/shared_linter_context'
-require 'haml_lint/spec/shared_rubocop_autocorrect_context'
-require 'haml_lint/spec/matchers/report_lint'
+require_relative 'spec/normalize_indent'
+require_relative 'spec/shared_linter_context'
+require_relative 'spec/shared_rubocop_autocorrect_context'
+require_relative 'spec/matchers/report_lint'

--- a/lib/haml_lint/tree/haml_comment_node.rb
+++ b/lib/haml_lint/tree/haml_comment_node.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'haml_lint/directive'
+require_relative '../directive'
 
 module HamlLint::Tree
   # Represents a HAML comment node.

--- a/lib/haml_lint/tree/node.rb
+++ b/lib/haml_lint/tree/node.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'haml_lint/comment_configuration'
+require_relative '../comment_configuration'
 
 module HamlLint::Tree
   # Decorator class that provides a convenient set of helpers for HAML's

--- a/lib/haml_lint/tree/root_node.rb
+++ b/lib/haml_lint/tree/root_node.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'haml_lint/tree/null_node'
+require_relative 'null_node'
 
 module HamlLint::Tree
   # Represents the root node of a HAML document that contains all other nodes.

--- a/lib/haml_lint/tree/script_node.rb
+++ b/lib/haml_lint/tree/script_node.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'haml_lint/parsed_ruby'
+require_relative '../parsed_ruby'
 
 module HamlLint::Tree
   # Represents a node which produces output based on Ruby code.


### PR DESCRIPTION
`require_relative` is preferred over `require` for files within the same project because it uses paths relative to the current file, making code more portable and less dependent on the load path.

This change updates internal requires to use `require_relative` for consistency, performance, and improved portability.

Retain require for dynamic paths in `lib/haml_lint.rb` because they use absolute paths.

Refs:
- rubocop/rubocop#8748

---

Hello, this should also provide a minor performance improvement in loading time because require_relative is `O(1)`, but please confirm my findings

`./bin/haml-lint --version` (with changes to prefer the current library) appears to be 7%/4.5% faster on M1 Pro, according to Ruby version and architecture

```
# 3.3.5 x64    `real` (avg of several runs)
`main`:        0m1.625s
`this branch`: 0m1.546s

# 3.3.3 arm64  `real` (avg of several runs)
`main`:        0m0.933s
`this branch`: 0m0.883s
```

---

If this is going to be accepted, I'll do the same for `slim-lint`