### PR TITLE
Update README to show that we run Appraisal on haml 5/6 not 4/5

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ attribute.
 We love getting feedback with or without pull requests. If you do add a new
 feature, please add tests so that we can avoid breaking it in the future.
 
-Speaking of tests, we use [Appraisal] to test against both HAML 4 and 5. We use
+Speaking of tests, we use [Appraisal] to test against both HAML 5 and 6. We use
 `rspec` to write our tests. To run the test suite, execute the following from
 the root directory of the repository:
 


### PR DESCRIPTION
**WHAT**

Update README to show that we run Appraisal on haml 5/6 not 4/5

**WHY**

Haml 4 compatibility was dropped in [this pr](https://github.com/sds/haml-lint/pull/466) as it was in `Appraisals`. There was not a corresponding update in the README to reflect this change and it still reads `we use Appraisal to test against both HAML 4 and 5` which is now out of date.