### PR TITLE
Set `Layout/First_#{}_LineBreak` lints as disabled in rubocop config

### DIFF
--- a/config/forced_rubocop_config.yml
+++ b/config/forced_rubocop_config.yml
@@ -45,6 +45,18 @@ Layout/EndAlignment:
 Layout/EndOfLine:
   Enabled: false
 
+# Complying with this lint requires the use of pipes which causes a conflict with MultilinePipe.
+Layout/FirstArrayElementLineBreak:
+  Enabled: false
+
+# Complying with this lint requires the use of pipes which causes a conflict with MultilinePipe.
+Layout/FirstHashElementLineBreak:
+  Enabled: false
+
+# Complying with this lint requires the use of pipes which causes a conflict with MultilinePipe.
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: false
+
 # Turning this cop on can turn
 # = content_tag(:span) do
 #   - foo


### PR DESCRIPTION
**What**

Set 3 of the 4 `Layout/First_#{}_LineBreak` lints as `enabled: false` in `config/forced_rubocop_config.yml`

- [Layout/FirstArrayElementLineBreak](https://docs.rubocop.org/rubocop/cops_layout.html#layoutfirstarrayelementlinebreak)
- [Layout/FirstHashElementLineBreak](https://docs.rubocop.org/rubocop/cops_layout.html#layoutfirsthashelementlinebreak)
- [Layout/FirstMethodArgumentLineBreak](https://docs.rubocop.org/rubocop/cops_layout.html#layoutfirstmethodargumentlinebreak)

Leaving 1 of the 4 as is:

- [Layout/FirstMethodParameterLineBreak](https://docs.rubocop.org/rubocop/cops_layout.html#layoutfirstmethodparameterlinebreak)

**Why**

These lints run into a conflict with [MultilinePipe](https://github.com/sds/haml-lint/blob/main/lib/haml_lint/linter/README.md#multilinepipe)

One example of this is that the autocorrect changes:

```
= link_to('View button styleguide',
  style_path('button'),
  target: '_blank',
  rel: 'noopener noreferrer')
```

to:

```
= link_to( |
  'View button styleguide', |
  style_path('button'), |
  target: '_blank', |
  rel: 'noopener noreferrer', |
  ) |
```

It is quite possible that this is showcasing a lack of understanding I have of haml syntax/best practice but I wasn't able to figure out a workaround that can satisfy both lints.

I left out [Layout/FirstMethodParameterLineBreak](https://docs.rubocop.org/rubocop/cops_layout.html#layoutfirstmethodparameterlinebreak) because in order to trigger this (which I couldn't figure out how to do without triggering a syntax error) you are probably doing something you shouldn't in the first place (defining a method inside a haml file is something that comes across to me as [bad practice](https://stackoverflow.com/questions/52117429/haml-how-to-define-a-method)) and an additional safeguard against this is probably a good thing.