### PR TITLE
Default to parallel true

### DIFF
--- a/lib/haml_lint/options.rb
+++ b/lib/haml_lint/options.rb
@@ -10,7 +10,7 @@ module HamlLint
     # @param args [Array<String>] arguments passed via the command line
     # @return [Hash] parsed options
     def parse(args)
-      @options = {}
+      @options = default_options
 
       OptionParser.new do |parser|
         parser.banner = "Usage: #{APP_NAME} [options] [file1, file2, ...]"
@@ -31,6 +31,10 @@ module HamlLint
     end
 
     private
+
+    def default_options
+      { parallel: true }
+    end
 
     def add_linter_options(parser) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       parser.on('--auto-gen-config', 'Generate a configuration file acting as a TODO list') do

--- a/lib/haml_lint/options.rb
+++ b/lib/haml_lint/options.rb
@@ -56,6 +56,10 @@ module HamlLint
         @options[:parallel] = true
       end
 
+      parser.on('--no-parallel', 'Disable parallel linter runs') do
+        @options[:parallel] = false
+      end
+
       parser.on('-a', '--auto-correct', 'Auto-correct offenses (only when it’s safe)') do
         @options[:autocorrect] = :safe
       end

--- a/spec/haml_lint/options_spec.rb
+++ b/spec/haml_lint/options_spec.rb
@@ -7,6 +7,12 @@ describe HamlLint::Options do
     subject { super().parse(args) }
     let(:args) { [] }
 
+    context 'without options' do
+      it 'sets the default values' do
+        subject[:parallel].should == true
+      end
+    end
+
     context 'with a configuration file specified' do
       let(:args) { %w[--config some-config.yml] }
 

--- a/spec/haml_lint/options_spec.rb
+++ b/spec/haml_lint/options_spec.rb
@@ -89,6 +89,14 @@ describe HamlLint::Options do
       end
     end
 
+    context 'with a no-parallel option' do
+      let(:args) { %w[--no-parallel] }
+
+      it 'sets the parallel option' do
+        subject[:parallel].should == false
+      end
+    end
+
     context 'with an auto-correct option' do
       let(:args) { %w[--auto-correct] }
 


### PR DESCRIPTION
Background: https://github.com/sds/haml-lint/issues/540

There didn't seem to be other default options set in this way at the options class level. To the extent there are defaults, they seem sort of spread around in constants or local context appropriate ways. Let me know if there's a different preferred way to do that.

- Changes parallel run default to true
- Adds `--no-parallel` option to turn it off
- Preserves behavior of previous `--parallel` option (though sort of moot now)

Possible follow-up -- do something with env vars or otherwise to specify number of CPU to use, instead of full parallel.