### PR TITLE
Update InstanceVariables linter to support :ruby filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HAML-Lint Changelog
 
+* Update `InstanceVariables` linter to support :ruby filters
+
 ### 0.59.0
 
 * Speed up load time by preferring `require_relative` in internal gem file loading

--- a/spec/haml_lint/linter/instance_variables_spec.rb
+++ b/spec/haml_lint/linter/instance_variables_spec.rb
@@ -4,7 +4,14 @@ RSpec.describe HamlLint::Linter::InstanceVariables do
   include_context 'linter'
 
   context 'when the file name does not match the matcher' do
-    let(:haml) { '%p= @greeting' }
+    let(:haml) do
+      [
+        '%p= @greeting',
+        '%p{ title: @greeting }',
+        ':ruby',
+        '  x = @greeting'
+      ].join("\n")
+    end
 
     it { should_not report_lint }
   end
@@ -221,6 +228,17 @@ RSpec.describe HamlLint::Linter::InstanceVariables do
         end
 
         it { should report_lint line: 2 }
+      end
+
+      context 'in a :ruby filter' do
+        let(:haml) do
+          [
+            ':ruby',
+            '  foo = @greeting',
+          ].join("\n")
+        end
+
+        it { should report_lint line: 1 }
       end
     end
   end


### PR DESCRIPTION
We sometimes use the :ruby filter as a preamble to our haml files, to set up local variables.

```haml
:ruby
  title = @page_title
%h1= title
```

How about something like this so that the InstanceVariables linter can detect ivars in filters?
