### PR TITLE
Allow `StrictLocals` to be disabled by a comment

### DIFF
--- a/lib/haml_lint/linter/strict_locals.rb
+++ b/lib/haml_lint/linter/strict_locals.rb
@@ -14,9 +14,12 @@ module HamlLint
     def visit_root(root)
       return unless enabled?(root)
 
-      first_children = root.children.first
-      return if first_children.is_a?(HamlLint::Tree::HamlCommentNode) &&
-                    first_children.is_strict_locals?
+      first_child = root.children.first
+      return if first_child.is_a?(HamlLint::Tree::HamlCommentNode) &&
+                    first_child.is_strict_locals?
+
+      # Check whether this linter is disabled by a comment
+      return if first_child.disabled?(self)
 
       record_lint(DummyNode.new(1), failure_message)
     end

--- a/spec/haml_lint/linter/strict_locals_spec.rb
+++ b/spec/haml_lint/linter/strict_locals_spec.rb
@@ -40,6 +40,17 @@ RSpec.describe HamlLint::Linter::StrictLocals do
 
       it { should report_lint line: 1 }
     end
+
+    context 'and the linter is disabled by a comment' do
+      let(:haml) do
+        <<~HAML
+          -# haml-lint:disable StrictLocals
+          %p Hello, world
+        HAML
+      end
+
+      it { should_not report_lint }
+    end
   end
 
   context 'with a custom matcher' do


### PR DESCRIPTION
Follow-up to https://github.com/sds/haml-lint/pull/553.

Because `StrictLocals` operates on the root node, it ignores the potential presence of a `haml-lint: disable` comment on the first line which means it can't be disabled that way.

This is unfortunate as I've often found those comments to be a useful tool to allow gradual adoption of a new lint.