### PR TITLE
Allow the strict locals comment to be preceeded by other comments

### DIFF
--- a/spec/haml_lint/linter/strict_locals_spec.rb
+++ b/spec/haml_lint/linter/strict_locals_spec.rb
@@ -35,8 +35,31 @@ RSpec.describe HamlLint::Linter::StrictLocals do
       it { should_not report_lint }
     end
 
+    context 'and there is a strict locals comment at the top of the file' do
+      let(:haml) do
+        <<~HAML
+          -# haml-lint:disable ViewLength
+          -# locals: (greeting:)
+          %p Hello, world
+        HAML
+      end
+
+      it { should_not report_lint }
+    end
+
     context 'and there is no strict locals comment' do
       let(:haml) { '%p Hello, world' }
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'and there is a strict locals comment after other nodes' do
+      let(:haml) do
+        <<~HAML
+          %p Hello, world
+          -# locals: (greeting:)
+        HAML
+      end
 
       it { should report_lint line: 1 }
     end


### PR DESCRIPTION
Follow-up to https://github.com/sds/haml-lint/pull/561 and https://github.com/sds/haml-lint/pull/553

Certain linters like `ViewLength` can be disabled via a `haml-lint:disable` comment but it must be the first thing in the file https://github.com/sds/haml-lint/blob/b248f8d3dae932fb2d285bbc2e441d52804b2a27/lib/haml_lint/linter/view_length.rb#L15-L17

This clashes with the `StrictLocals` lint as it currently reports an error for cases like this

```haml
-# haml-lint:disable ViewLength
-# locals: (foo: )
```

as it expects the strict locals comment to come first despite it being completely valid from Rails' standpoint. As per https://guides.rubyonrails.org/action_view_overview.html#strict-locals it can be anywhere in the file:

> Action View will process the `locals:` signature in any templating engine that supports `#`-prefixed comments, and will read the signature from any line in the partial.

As a middle ground I've 
- Kept the restriction that `StrictLocals` can only be disabled by comment if it's the first thing in the file (to mirror `ViewLength`'s behaviour)
- Allowed the strict locals comment to appear anywhere in a series of comments at the top of the file (as I still think having it at the top is preferable)