### PR TITLE
Faster runs via RuboCop::Runner

### DIFF
--- a/lib/haml_lint/linter/rubocop.rb
+++ b/lib/haml_lint/linter/rubocop.rb
@@ -297,15 +297,23 @@ module HamlLint
                                    corrected: corrected)
     end
 
+    # rubocop:disable Style/MutableConstant
+    DEFAULT_FLAGS = %w[--format RuboCop::Formatter::BaseFormatter]
+    begin
+      ::RuboCop::Options.new.parse(['--raise-cop-error'])
+      DEFAULT_FLAGS << '--raise-cop-error'
+    rescue OptionParser::InvalidOption
+      # older versions of RuboCop don't support this flag
+    end
+    DEFAULT_FLAGS.freeze
+    # rubocop:enable Style/MutableConstant
+
     # Returns options that will be passed to the RuboCop runner.
     #
     # @return [Hash]
     def rubocop_options
       # using BaseFormatter suppresses any default output
-      flags = %w[
-        --format RuboCop::Formatter::BaseFormatter
-        --raise-cop-error
-      ]
+      flags = DEFAULT_FLAGS
       flags += ignored_cops_flags
       flags += rubocop_autocorrect_flags
       options, _args = ::RuboCop::Options.new.parse(flags)

--- a/spec/haml_lint/linter/rubocop_spec.rb
+++ b/spec/haml_lint/linter/rubocop_spec.rb
@@ -13,10 +13,10 @@ describe HamlLint::Linter::RuboCop do
     # Need this block before including linter context so that stubbing occurs
     # before linter is run
     before do
-      rubocop_runner.stub(:run)
       subject.stub(:rubocop_runner).and_return(rubocop_runner)
-      HamlLint::OffenseCollector.stub(:offenses)
-                                .and_return([offence].compact)
+      rubocop_runner.stub(:run)
+      rubocop_runner.stub(:offenses)
+                    .and_return([offence].compact)
     end
 
     include_context 'linter'
@@ -339,7 +339,7 @@ describe HamlLint::Linter::RuboCop do
 
     before do
       HamlLint::Linter::RuboCop::Runner.stub(:new).and_return(rubocop_runner)
-      HamlLint::OffenseCollector.stub(:offenses).and_return([])
+      rubocop_runner.stub(:offenses).and_return([])
     end
 
     context 'when RuboCop returns true' do
@@ -352,7 +352,7 @@ describe HamlLint::Linter::RuboCop do
       let(:offense) { spy('offense') }
       before do
         rubocop_runner.stub(:run) do
-          HamlLint::OffenseCollector.offenses << offense
+          rubocop_runner.offenses << offense
         end
       end
 

--- a/spec/haml_lint/linter/rubocop_spec.rb
+++ b/spec/haml_lint/linter/rubocop_spec.rb
@@ -14,7 +14,7 @@ describe HamlLint::Linter::RuboCop do
     # before linter is run
     before do
       rubocop_cli.stub(:run).and_return(::RuboCop::CLI::STATUS_SUCCESS)
-      HamlLint::Linter::RuboCop.stub(:rubocop_cli).and_return(rubocop_cli)
+      subject.stub(:rubocop_cli).and_return(rubocop_cli)
       HamlLint::OffenseCollector.stub(:offenses)
                                 .and_return([offence].compact)
     end


### PR DESCRIPTION
Every time we call `RuboCop::CLI#run` (which happens once per file being linted), it sets up a new RuboCop::Runner.
This is pretty slow, especially from `RuboCop::Options#parse` and `RuboCop::Runner#mobilized_cop_classes`.

We can skip all this repeated setup by using RuboCop::Runner directly. This also means we don't have to capture the stdout/stderr streams from CLI, since the relevant information is available directly on the runner instance.

Before:

```
626 files inspected, 0 lints detected

________________________________________________________
Executed in   23.22 secs    fish           external
   usr time   20.12 secs    0.32 millis   20.12 secs
   sys time    2.57 secs    2.49 millis    2.56 secs
```

After:

```
626 files inspected, 0 lints detected

________________________________________________________
Executed in   17.64 secs    fish           external
   usr time   15.30 secs    0.34 millis   15.30 secs
   sys time    1.93 secs    2.60 millis    1.93 secs
```

I've introduced a subclass of RuboCop::Runner to handle some of the customizations we need. ruby-lsp have a similar approach here - https://github.com/Shopify/ruby-lsp/blob/13bb8b0addf96248a951dca988e40127c86b6ba8/lib/ruby_lsp/requests/support/rubocop_runner.rb#L54, which might be useful for comparison.




