### PR TITLE
Enable RuboCop caching

### DIFF
--- a/lib/haml_lint/document.rb
+++ b/lib/haml_lint/document.rb
@@ -14,6 +14,9 @@ module HamlLint
     # @return [String] Haml template file path
     attr_reader :file
 
+    # @return [Boolean] true if source was read directly from `file` on-disk (rather than from stdin)
+    attr_reader :file_on_disk
+
     # @return [Boolean] true if source changes (from autocorrect) should be written to stdout instead of disk
     attr_reader :write_to_stdout
 
@@ -39,12 +42,14 @@ module HamlLint
     # @param source [String] Haml code to parse
     # @param options [Hash]
     # @option options :file [String] file name of document that was parsed
+    # @option options :file_on_disk [Boolean] true if source was read straight from `file` on disk
     # @option options :write_to_stdout [Boolean] true if source changes should be written to stdout
     # @raise [Haml::Parser::Error] if there was a problem parsing the document
     def initialize(source, options)
       @config = options[:config]
       @file = options.fetch(:file, STRING_SOURCE)
       @write_to_stdout = options[:write_to_stdout]
+      @file_on_disk = options[:file_on_disk] && @file != STRING_SOURCE
       @source_was_changed = false
       process_source(source)
     end

--- a/lib/haml_lint/runner.rb
+++ b/lib/haml_lint/runner.rb
@@ -89,6 +89,7 @@ module HamlLint
       begin
         document = HamlLint::Document.new source.contents, file: source.path,
                                                            config: config,
+                                                           file_on_disk: !source.stdin?,
                                                            write_to_stdout: @autocorrect_stdout
       rescue HamlLint::Exceptions::ParseError => e
         return [HamlLint::Lint.new(HamlLint::Linter::Syntax.new(config), source.path,

--- a/lib/haml_lint/source.rb
+++ b/lib/haml_lint/source.rb
@@ -20,5 +20,10 @@ module HamlLint
     def contents
       @contents ||= @io&.read || File.read(path)
     end
+
+    # @return [boolean] true if we're reading from stdin rather than a file path
+    def stdin?
+      !@io.nil?
+    end
   end
 end

--- a/lib/haml_lint/utils.rb
+++ b/lib/haml_lint/utils.rb
@@ -249,34 +249,6 @@ module HamlLint
       $!
     end
 
-    # Overrides the global stdin, stdout and stderr while within the block, to
-    # push a string in stdin, and capture both stdout and stderr which are returned.
-    #
-    # @param stdin_str [String] the string to push in as stdin
-    # @param _block [Block] the block to perform with the overridden std streams
-    # @return [String, String]
-    def with_captured_streams(stdin_str, &_block)
-      original_stdin = $stdin
-      # The dup is needed so that stdin_data isn't altered (encoding-wise at least)
-      $stdin = StringIO.new(stdin_str.dup)
-      begin
-        original_stdout = $stdout
-        $stdout = StringIO.new
-        begin
-          original_stderr = $stderr
-          $stderr = StringIO.new
-          yield
-          [$stdout.string, $stderr.string]
-        ensure
-          $stderr = original_stderr
-        end
-      ensure
-        $stdout = original_stdout
-      end
-    ensure
-      $stdin = original_stdin
-    end
-
     def regexp_for_parts(parts, join_regexp, prefix: nil, suffix: nil)
       regexp_code = parts.map { |c| Regexp.quote(c) }.join(join_regexp)
       regexp_code = "#{prefix}#{regexp_code}#{suffix}"

--- a/spec/haml_lint/linter/rubocop_spec.rb
+++ b/spec/haml_lint/linter/rubocop_spec.rb
@@ -158,14 +158,14 @@ describe HamlLint::Linter::RuboCop do
 
     context 'when the config_file specifies a relative config that disable that cop' do
       let(:config) do
-        # need to be an instance variable to avoid the TempFile cleaning up too soon
         tmp_dir = File.join(__dir__, '../../tmp')
         FileUtils.mkdir_p(tmp_dir)
-        config_file = Tempfile.new(%w[my-rubo-cop.yml], tmp_dir).tap do |f|
+        # need to be an instance variable to avoid the TempFile cleaning up too soon
+        @config_file = Tempfile.new(%w[my-rubo-cop.yml], tmp_dir).tap do |f|
           f.write("Lint/UselessAssignment:\n  Enabled: false\n")
           f.close
         end
-        rel_config_path = Pathname.new(config_file.path).relative_path_from(File.expand_path('.')).to_s
+        rel_config_path = Pathname.new(@config_file.path).relative_path_from(File.expand_path('.')).to_s
         super().merge('config_file' => rel_config_path)
       end
 


### PR DESCRIPTION
Because we call RuboCop::Runner with the extracted ruby code on stdin, RuboCop thinks that its cache ought to be disabled. (https://github.com/rubocop/rubocop/blob/0bb3b4ffdf0568ea978512947e9a027a35caba83/lib/rubocop/runner.rb#L253-L263)

Override the `RuboCop::Runner#cached_run?` method so that if haml-lint itself isn't using code from stdin, RuboCop is allowed to cache results based on a hash of the haml file.

Before:

```
$ bundle exec haml-lint app/{components,views}

626 files inspected, 0 lints detected

________________________________________________________
Executed in    5.06 secs    fish           external
   usr time   23.90 secs  340.00 micros   23.90 secs
   sys time    3.99 secs  993.00 micros    3.99 secs
```

After:

```
$ bundle exec haml-lint app/{components,views}

626 files inspected, 0 lints detected

________________________________________________________
Executed in    2.65 secs    fish           external
   usr time    8.78 secs    0.53 millis    8.78 secs
   sys time    2.19 secs    5.11 millis    2.18 secs
```


---

This seems to have been working well for me locally, but would definitely appreciate some more testing from others.
