### PR TITLE
Alphabetize lints when generating todo file

### DIFF
--- a/lib/haml_lint/reporter/disabled_config_reporter.rb
+++ b/lib/haml_lint/reporter/disabled_config_reporter.rb
@@ -88,7 +88,7 @@ module HamlLint
       output = []
       output << HEADING
       output << 'linters:' if linters_with_lints.any?
-      linters_with_lints.each do |linter, files|
+      linters_with_lints.sort.each do |linter, files|
         output << generate_config_for_linter(linter, files)
       end
       output.join("\n\n")

--- a/spec/haml_lint/reporter/disabled_config_reporter_spec.rb
+++ b/spec/haml_lint/reporter/disabled_config_reporter_spec.rb
@@ -102,15 +102,15 @@ RSpec.describe HamlLint::Reporter::DisabledConfigReporter do
             '',
             'linters:',
             '',
+            '  # Offense count: 16',
+            '  OtherLinter:',
+            '    enabled: false',
+            '',
             '  # Offense count: 3',
             '  SomeLinter:',
             '    exclude:',
             '      - "other-filename.haml"',
             '      - "some-filename.haml"',
-            '',
-            '  # Offense count: 16',
-            '  OtherLinter:',
-            '    enabled: false'
           ].join("\n")
       end
 
@@ -125,13 +125,13 @@ RSpec.describe HamlLint::Reporter::DisabledConfigReporter do
               '',
               'linters:',
               '',
+              '  # Offense count: 16',
+              '  OtherLinter:',
+              '    enabled: false',
+              '',
               '  # Offense count: 3',
               '  SomeLinter:',
               '    enabled: false',
-              '',
-              '  # Offense count: 16',
-              '  OtherLinter:',
-              '    enabled: false'
             ].join("\n")
         end
       end


### PR DESCRIPTION
**What**

Alphabetize lints when generating todo file

**Why**

Makes the todo files a bit easier to read through.