### PR TITLE
Make sure todo file generates with a newline at the end

### DIFF
--- a/lib/haml_lint/reporter/disabled_config_reporter.rb
+++ b/lib/haml_lint/reporter/disabled_config_reporter.rb
@@ -91,7 +91,7 @@ module HamlLint
       linters_with_lints.sort.each do |linter, files|
         output << generate_config_for_linter(linter, files)
       end
-      output.join("\n\n")
+      output.join("\n\n") + "\n"
     end
 
     # Constructs the configuration for excluding a linter in some files.

--- a/spec/haml_lint/reporter/disabled_config_reporter_spec.rb
+++ b/spec/haml_lint/reporter/disabled_config_reporter_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe HamlLint::Reporter::DisabledConfigReporter do
 
       it 'creates a file with just a header' do
         subject
-        config.should == described_class::HEADING
+        config.should == described_class::HEADING + "\n"
       end
     end
 
@@ -111,6 +111,7 @@ RSpec.describe HamlLint::Reporter::DisabledConfigReporter do
             '    exclude:',
             '      - "other-filename.haml"',
             '      - "some-filename.haml"',
+            '',
           ].join("\n")
       end
 
@@ -132,6 +133,7 @@ RSpec.describe HamlLint::Reporter::DisabledConfigReporter do
               '  # Offense count: 3',
               '  SomeLinter:',
               '    enabled: false',
+              '',
             ].join("\n")
         end
       end


### PR DESCRIPTION
**What**

Make sure todo file generates with a newline at the end

**Why**

Everytime I regenerate a haml lint todo file I have to manually add in a newline so that we don't lose it.

**Notes**

This matches how rubocop works as can be seen in the contents of [spec/rubocop/formatter/disabled_config_formatter_spec.rb](https://github.com/rubocop/rubocop/blob/6c522f8db358fdcc19381cd88e77f0d08ffed1b6/spec/rubocop/formatter/disabled_config_formatter_spec.rb#L105-L121):

```
let(:expected_rubocop_todo) do
  [heading,
    '# Offense count: 2',
    'Test/Cop1:',
    '  Exclude:',
    "    - 'Gemfile'",
    "    - 'test_a.rb'",
    "    - 'test_b.rb'",
    '',
    '# Offense count: 1',
    'Test/Cop2:',
    '  Exclude:',
    "    - '**/*.blah'",
    '    - !ruby/regexp /.*/bar/*/foo\.rb$/',
    "    - 'test_a.rb'",
    ''].join("\n")
end
```