### PR TITLE
Update RuboCop and its configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
 
 AllCops:
@@ -85,7 +85,7 @@ Style/PercentLiteralDelimiters:
 
 # Renaming `has_something?` to `something?` obfuscates whether it is a "is-a" or
 # a "has-a" relationship.
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Enabled: false
 
 Style/SignalException:

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'appraisal'
 gem 'overcommit', '0.68.0'
 
 # Pin tool versions (which are executed by Overcommit) for CI builds
-gem 'rubocop', '1.78.0'
+gem 'rubocop', '1.79.1'
 gem 'rubocop-performance', '1.25.0'
 
 gem 'simplecov', '~> 0.22.0'


### PR DESCRIPTION
Eliminate warnings:
- Use `plugins` instead of `require`
- Rename `Naming/PredicateName` to `Naming/PredicatePrefix`

Supersede #586

---

### Before

```
$ be rubocop
rubocop-performance extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance` in .rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

Warning: The `Naming/PredicateName` cop has been renamed to `Naming/PredicatePrefix`.
(obsolete configuration found in .rubocop.yml, please update it)
Warning: Using `Naming/PredicateName` configuration in .rubocop.yml for `Naming/PredicatePrefix`.
```