### PR TITLE
Use `match?` to reduce memory allocations

### DIFF
--- a/lib/haml_lint/linter/instance_variables.rb
+++ b/lib/haml_lint/linter/instance_variables.rb
@@ -10,7 +10,7 @@ module HamlLint
     # @param [HamlLint::Tree::RootNode] the root of a syntax tree
     # @return [true, false] whether the linter is enabled for the tree
     def visit_root(node)
-      @enabled = matcher.match(File.basename(node.file)) ? true : false
+      @enabled = matcher.match?(File.basename(node.file))
     end
 
     # Checks for instance variables in script nodes when the linter is enabled.

--- a/lib/haml_lint/linter/multiline_pipe.rb
+++ b/lib/haml_lint/linter/multiline_pipe.rb
@@ -26,7 +26,7 @@ module HamlLint
       # Plain text nodes are allowed to consist of a single pipe
       return if line.strip == '|'
 
-      record_lint(node, MESSAGE) if line.match(MULTILINE_PIPE_REGEX)
+      record_lint(node, MESSAGE) if line.match?(MULTILINE_PIPE_REGEX)
     end
 
     private
@@ -39,7 +39,7 @@ module HamlLint
 
     def check(node)
       line = line_text_for_node(node)
-      record_lint(node, MESSAGE) if line.match(MULTILINE_PIPE_REGEX)
+      record_lint(node, MESSAGE) if line.match?(MULTILINE_PIPE_REGEX)
     end
   end
 end

--- a/lib/haml_lint/linter/strict_locals.rb
+++ b/lib/haml_lint/linter/strict_locals.rb
@@ -35,7 +35,7 @@ module HamlLint
     # @api private
     # @return [true, false]
     def enabled?(root)
-      return false unless matcher.match(File.basename(root.file))
+      return false unless matcher.match?(File.basename(root.file))
 
       # This linter can also be disabled by a comment at the top of the file
       first_child = root.children.first


### PR DESCRIPTION
Replace instances of `match` where the result is only used for its
truthiness.

The `match?` method returns a boolean and avoids creating a `MatchData`
object, reducing memory allocations and improving performance.