### PR TITLE
Drop defunct codeclimate badge image from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Gem Version](https://badge.fury.io/rb/haml_lint.svg)](http://badge.fury.io/rb/haml_lint)
 [![Build Status](https://github.com/sds/haml-lint/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/sds/haml-lint/actions/workflows/tests.yml?branch=main)
-[![Maintainability](https://api.codeclimate.com/v1/badges/b1f81df6b0922ff5bcdd/maintainability)](https://codeclimate.com/github/sds/haml-lint/maintainability)
 [![Coverage Status](https://coveralls.io/repos/sds/haml-lint/badge.svg)](https://coveralls.io/r/sds/haml-lint)
 [![Inline docs](http://inch-ci.org/github/sds/haml-lint.svg?branch=master)](http://inch-ci.org/github/sds/haml-lint)
 


### PR DESCRIPTION
The image no longer displays, the service is gone.