### PR TITLE
Add support for Haml 6.4 and 7.0

### DIFF
--- a/lib/haml_lint/adapter.rb
+++ b/lib/haml_lint/adapter.rb
@@ -19,7 +19,8 @@ module HamlLint
       version = haml_version
       case version
       when '~> 5.0', '~> 5.1', '~> 5.2' then HamlLint::Adapter::Haml5
-      when '~> 6.0', '~> 6.0.a', '~> 6.1', '~> 6.2', '~> 6.3' then HamlLint::Adapter::Haml6
+      when '~> 6.0', '~> 6.0.a', '~> 6.1', '~> 6.2', '~> 6.3', '~> 6.4' then HamlLint::Adapter::Haml6
+      when '~> 7.0' then HamlLint::Adapter::Haml6
       else fail HamlLint::Exceptions::UnknownHamlVersion, "Cannot handle Haml version: #{version}"
       end
     end


### PR DESCRIPTION
Extends the Adapter to recognize Haml 6.4 and 7.0, using the existing Haml6 adapter class for both versions. The Haml 7.0 release only introduces non-breaking changes (default attribute quote change and Ruby 3.2+ requirement) with no parser API modifications, making it fully compatible with the Haml6 adapter. Fixes #604