### PR TITLE
Fix RuboCop deprecation warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
 
 AllCops:
@@ -85,7 +85,7 @@ Style/PercentLiteralDelimiters:
 
 # Renaming `has_something?` to `something?` obfuscates whether it is a "is-a" or
 # a "has-a" relationship.
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Enabled: false
 
 Style/SignalException:


### PR DESCRIPTION
## Summary

- Switch `require: rubocop-performance` to `plugins: rubocop-performance` per RuboCop's new plugin system
- Rename `Naming/PredicateName` cop to `Naming/PredicatePrefix` to match the upstream rename

## Test plan

- [x] `bundle exec rubocop` runs clean with no warnings and no offenses