### PR TITLE
Add tsort to rubocop1.0 gemfile to fix deprecation warning

### DIFF
--- a/gemfiles/rubocop1.0.gemfile
+++ b/gemfiles/rubocop1.0.gemfile
@@ -13,5 +13,6 @@ gem "simplecov", "~> 0.22.0"
 gem "simplecov-lcov", "~> 0.9.0"
 gem "base64"
 gem "ostruct"
+gem "tsort"
 
 gemspec path: "../"


### PR DESCRIPTION
## Summary

- Add `tsort` gem to `gemfiles/rubocop1.0.gemfile` to silence Ruby 4.0 deprecation warning
- RuboCop 1.0 uses `tsort` internally, which was extracted from Ruby's default gems in 4.0
- Matches the existing `base64` and `ostruct` shims already in that gemfile

## Test plan

- [x] `BUNDLE_GEMFILE=gemfiles/rubocop1.0.gemfile bundle exec rspec` runs with no deprecation warnings and no new failures