### PR TITLE
Add auto-correction to HAML-level linters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # HAML-Lint Changelog
 
+### Unreleased
+
+* Add auto-correction (`-a`/`--auto-correct` and `-A`/`--auto-correct-all`) to HAML-level linters.
+  * Safe corrections (run under both `-a` and `-A`): `ClassAttributeWithStaticValue`,
+    `ClassesBeforeIds`, `EmptyObjectReference`, `FinalNewline`,
+    `ImplicitDiv`, `LeadingCommentSpace`, `RubyComments`, `SpaceBeforeScript`,
+    `SpaceInsideHashAttributes`, `TagName`, `TrailingEmptyLines`, `TrailingWhitespace`, and
+    `UnnecessaryInterpolation`.
+  * Unsafe corrections (run only under `-A`): `ConsecutiveComments`, `EmptyScript`, and `MultilineScript`
+
 ### 0.73.0
 
 * Relax `parallel` dependency from `~> 1.10` to `>= 1.10`

--- a/lib/haml_lint/linter.rb
+++ b/lib/haml_lint/linter.rb
@@ -63,6 +63,7 @@ module HamlLint
       @document = document
       @lints = []
       @autocorrect = autocorrect
+      reset_autocorrect_state
       visit(document.tree)
       @lints
     end
@@ -85,6 +86,30 @@ module HamlLint
       self.class.supports_autocorrect?
     end
 
+    # Returns whether this linter's autocorrect is safe. Defaults to true (safe)
+    # unless the linter declares otherwise via `autocorrect_safe(false)`.
+    #
+    # @return [Boolean]
+    def self.autocorrect_safe?
+      @autocorrect_safe != false
+    end
+
+    # The autocorrect ordering priority for this linter. During autocorrect,
+    # linters with a lower priority run first and higher priority run later,
+    # against the same (already mutated) document. Linters with the same priority
+    # keep their default (alphabetical) order.
+    #
+    # Called with an argument (e.g. `autocorrect_priority(1)`) in a linter's
+    # top-level scope, it sets the priority; called with no argument it reads it.
+    # The default, when never set, is 0.
+    #
+    # @param value [Integer, nil] the new priority, or nil to read the current one
+    # @return [Integer]
+    def self.autocorrect_priority(value = nil)
+      @autocorrect_priority = value unless value.nil?
+      @autocorrect_priority || 0
+    end
+
     private
 
     attr_reader :config, :document
@@ -95,6 +120,92 @@ module HamlLint
     # @params value [Boolean] The new value for supports_autocorrect
     private_class_method def self.supports_autocorrect(value)
       @supports_autocorrect = value
+    end
+
+    # Linters can call autocorrect_safe(false) in their top-level scope to declare that their
+    # autocorrect is unsafe, meaning it only runs under `--auto-correct-all` (`:all`).
+    # The default, when not called, is safe.
+    #
+    # @params value [Boolean] The new value for autocorrect_safe
+    private_class_method def self.autocorrect_safe(value)
+      @autocorrect_safe = value
+    end
+
+    # Resets the per-run autocorrect bookkeeping. Linter instances are reused
+    # across files, so subclasses that accumulate extra autocorrect state during
+    # a traversal (e.g. a list of lines to merge or delete) must override this,
+    # calling `super`, to clear that state between files. Otherwise corrections
+    # from one file leak into the next.
+    def reset_autocorrect_state
+      @autocorrected_lines = nil
+      @autocorrect_changed = false
+    end
+
+    # Whether the linter is currently allowed to apply autocorrections, given the active
+    # autocorrect mode and this linter's declared safety:
+    #
+    #   * safe linters correct under both `:safe` and `:all`;
+    #   * unsafe linters correct only under `:all`;
+    #   * with no mode (`nil`) nothing is corrected (detection only).
+    #
+    # @return [Boolean]
+    def autocorrect?
+      case @autocorrect
+      when :all
+        true
+      when :safe
+        self.class.autocorrect_safe?
+      else
+        false
+      end
+    end
+
+    # Applies a corrected, full-document source to the document through the single
+    # mutation path (`Document#change_source`), but only when the safety gate permits.
+    # No-ops otherwise; `change_source` itself also no-ops when the source is unchanged.
+    #
+    # @param new_source [String] the corrected HAML source
+    def apply_autocorrect(new_source)
+      return unless autocorrect?
+      document.change_source(new_source)
+    end
+
+    # Lazily-initialized working copy of the document's source lines, used to
+    # accumulate line-level corrections during a single tree traversal. Editing
+    # this copy (rather than calling `apply_autocorrect` per node) avoids
+    # reparsing the document mid-walk, which would invalidate the tree being
+    # visited.
+    #
+    # @return [Array<String>]
+    def autocorrected_lines
+      @autocorrected_lines ||= document.source_lines.dup
+    end
+
+    # Replaces a single source line (0-indexed) in the working copy, but only
+    # when autocorrect is permitted and the new text actually differs.
+    #
+    # @param index [Integer] the 0-indexed line to replace
+    # @param new_text [String] the corrected line
+    # @return [Boolean] true if a change was recorded, false otherwise
+    def correct_line(index, new_text)
+      return false unless autocorrect?
+      return false if autocorrected_lines[index] == new_text
+
+      autocorrected_lines[index] = new_text
+      @autocorrect_changed = true
+    end
+
+    # Flushes any corrections accumulated via `correct_line` through the single
+    # mutation path, once, after the whole tree has been visited. Defined on the
+    # base so per-node linters need no boilerplate; no-ops for linters that never
+    # accumulated a change (including those that apply within `visit_root`).
+    #
+    # NOTE: a linter that overrides `after_visit_root` must call `super`, or
+    # accumulated corrections will not be applied.
+    def after_visit_root(_node)
+      return unless @autocorrect_changed
+
+      apply_autocorrect(autocorrected_lines.join("\n"))
     end
 
     # Record a lint for reporting back to the user.

--- a/lib/haml_lint/linter/class_attribute_with_static_value.rb
+++ b/lib/haml_lint/linter/class_attribute_with_static_value.rb
@@ -18,15 +18,19 @@ module HamlLint
   class Linter::ClassAttributeWithStaticValue < Linter
     include LinterRegistry
 
+    supports_autocorrect(true)
+
     STATIC_TYPES = %i[str sym].freeze
 
     VALID_CLASS_REGEX = /^-?[_a-zA-Z]+[_a-zA-Z0-9-]*$/
 
     def visit_tag(node)
-      return unless contains_class_attribute?(node.dynamic_attributes_sources)
+      class_value = static_class_value(node.dynamic_attributes_sources)
+      return unless class_value
 
+      corrected = correct_class_attribute(node, class_value)
       record_lint(node, 'Avoid defining `class` in attributes hash ' \
-                        'for static class names')
+                        'for static class names', corrected: corrected)
     end
 
     private
@@ -35,28 +39,64 @@ module HamlLint
       code.start_with?('{') && code.end_with?('}')
     end
 
-    def contains_class_attribute?(attributes_sources)
+    # @return [String, nil]
+    def static_class_value(attributes_sources)
       attributes_sources.each do |code|
         ast_root = parse_ruby(surrounded_by_braces?(code) ? code : "{#{code}}")
         next unless ast_root # RuboCop linter will report syntax errors
 
         ast_root.children.each do |pair|
-          return true if static_class_attribute_value?(pair)
+          value = static_class_attribute_value(pair)
+          return value if value
         end
       end
 
-      false
+      nil
     end
 
-    def static_class_attribute_value?(pair)
-      return false if (children = pair.children).empty?
+    # @return [String, nil]
+    def static_class_attribute_value(pair)
+      return nil if (children = pair.children).empty?
 
       key, value = children
 
-      STATIC_TYPES.include?(key.type) &&
-        key.children.first.to_sym == :class &&
-        STATIC_TYPES.include?(value.type) &&
-        value.children.first =~ VALID_CLASS_REGEX
+      return nil unless STATIC_TYPES.include?(key.type) &&
+                        key.children.first.to_sym == :class &&
+                        STATIC_TYPES.include?(value.type)
+
+      class_name = value.children.first.to_s
+      VALID_CLASS_REGEX.match?(class_name) ? class_name : nil
+    end
+
+    # @return [Boolean]
+    def correct_class_attribute(node, class_value)
+      hash_source = node.hash_attributes_source
+      return false unless hash_source
+      return false if hash_source.include?("\n")
+      return false unless node.dynamic_attributes_source.keys == [:hash]
+      return false unless sole_pair?(node.dynamic_attributes_sources)
+      return false if node.static_classes.flatten.include?(class_value)
+
+      index = node.line - 1
+      line = autocorrected_lines[index]
+      old = "#{node.static_attributes_source}#{hash_source}"
+      return false unless line.include?(old)
+
+      new = "#{node.static_attributes_source}.#{class_value}"
+      correct_line(index, line.sub(old, new))
+    end
+
+    # Whether the attribute hash contains exactly one key/value pair (the class).
+    #
+    # @return [Boolean]
+    def sole_pair?(attributes_sources)
+      return false unless attributes_sources.size == 1
+
+      code = attributes_sources.first
+      ast_root = parse_ruby(surrounded_by_braces?(code) ? code : "{#{code}}")
+      return false unless ast_root
+
+      ast_root.children.size == 1
     end
   end
 end

--- a/lib/haml_lint/linter/classes_before_ids.rb
+++ b/lib/haml_lint/linter/classes_before_ids.rb
@@ -5,6 +5,8 @@ module HamlLint
   class Linter::ClassesBeforeIds < Linter
     include LinterRegistry
 
+    supports_autocorrect(true)
+
     MSG = '%s should be listed before %s (%s should precede %s)'
 
     def visit_tag(node)
@@ -17,13 +19,26 @@ module HamlLint
         next unless next_val.start_with?(first) &&
                     current_val.start_with?(second)
 
+        corrected = correct_attribute_order(node, components)
         failure_message = format(MSG, *(attribute_type_order + [next_val, current_val]))
-        record_lint(node, failure_message)
+        record_lint(node, failure_message, corrected: corrected)
         break
       end
     end
 
     private
+
+    # @param node [HamlLint::Tree::TagNode]
+    # @param components [Array<String>] the `.class`/`#id` components in source order
+    # @return [Boolean]
+    def correct_attribute_order(node, components)
+      classes, ids = components.partition { |component| component.start_with?('.') }
+      new_source = (ids_first? ? ids + classes : classes + ids).join
+
+      index = node.line - 1
+      line = autocorrected_lines[index]
+      correct_line(index, line.sub(node.static_attributes_source, new_source))
+    end
 
     def attribute_prefix_order
       default = %w[. #]

--- a/lib/haml_lint/linter/consecutive_comments.rb
+++ b/lib/haml_lint/linter/consecutive_comments.rb
@@ -5,6 +5,9 @@ module HamlLint
   class Linter::ConsecutiveComments < Linter
     include LinterRegistry
 
+    supports_autocorrect(true)
+    autocorrect_safe(false)
+
     COMMENT_DETECTOR = ->(child) { child.type == :haml_comment }
 
     def visit_haml_comment(node)
@@ -16,12 +19,28 @@ module HamlLint
         config['max_consecutive'] + 1,
       ) do |group|
         group.each { |group_node| reported_nodes << group_node }
+        corrected = correct_group(group)
         record_lint(group.first,
-                    "#{group.count} consecutive comments can be merged into one")
+                    "#{group.count} consecutive comments can be merged into one",
+                    corrected: corrected)
       end
     end
 
     private
+
+    # @return [Boolean]
+    def correct_group(group)
+      first_index = group.first.line - 1
+      continuation_indent = "#{autocorrected_lines[first_index][/\A\s*/]}   "
+
+      changed = false
+      group[1..].each do |group_node|
+        index = group_node.line - 1
+        line = autocorrected_lines[index]
+        changed = true if correct_line(index, continuation_indent + line.sub(/\A\s*-#\s?/, ''))
+      end
+      changed
+    end
 
     def possible_group(node)
       node.subsequents.unshift(node)

--- a/lib/haml_lint/linter/empty_object_reference.rb
+++ b/lib/haml_lint/linter/empty_object_reference.rb
@@ -5,11 +5,26 @@ module HamlLint
   class Linter::EmptyObjectReference < Linter
     include LinterRegistry
 
+    supports_autocorrect(true)
+
     def visit_tag(node)
       return unless node.object_reference? &&
                     node.object_reference_source.strip.empty?
 
-      record_lint(node, 'Empty object reference should be removed')
+      corrected = correct_object_reference(node)
+      record_lint(node, 'Empty object reference should be removed', corrected: corrected)
+    end
+
+    private
+
+    # @return [Boolean]
+    def correct_object_reference(node)
+      index = node.line - 1
+      line = autocorrected_lines[index]
+      # `static_attributes_source` is just the `.class`/`#id` part (e.g. `.foo`),
+      # so the optional `%tag` group captures an explicit tag name when present.
+      static = Regexp.escape(node.static_attributes_source)
+      correct_line(index, line.sub(/\A(\s*(?:%[-:\w]+)?#{static})\[\s*\]/, '\1'))
     end
   end
 end

--- a/lib/haml_lint/linter/empty_script.rb
+++ b/lib/haml_lint/linter/empty_script.rb
@@ -5,10 +5,40 @@ module HamlLint
   class Linter::EmptyScript < Linter
     include LinterRegistry
 
+    supports_autocorrect(true)
+    autocorrect_safe(false)
+
     def visit_silent_script(node)
       return unless /\A\s*\Z/.match?(node.script)
 
-      record_lint(node, 'Empty script should be removed')
+      # Only a childless `-` can be deleted; a `-` with children is degenerate
+      # but is still reported.
+      deletable = node.children.empty?
+      deleted_lines << (node.line - 1) if autocorrect? && deletable
+      record_lint(node, 'Empty script should be removed',
+                  corrected: autocorrect? && deletable)
+    end
+
+    def after_visit_root(node)
+      super
+      return if deleted_lines.empty?
+
+      kept = document.source_lines.reject.with_index do |_, index|
+        deleted_lines.include?(index)
+      end
+      apply_autocorrect(kept.join("\n"))
+    end
+
+    private
+
+    def reset_autocorrect_state
+      super
+      @deleted_lines = []
+    end
+
+    # @return [Array<Integer>]
+    def deleted_lines
+      @deleted_lines ||= []
     end
   end
 end

--- a/lib/haml_lint/linter/final_newline.rb
+++ b/lib/haml_lint/linter/final_newline.rb
@@ -5,6 +5,12 @@ module HamlLint
   class Linter::FinalNewline < Linter
     include LinterRegistry
 
+    supports_autocorrect(true)
+
+    # Run last during autocorrect, so any line-level corrections from other
+    # linters are applied before the trailing newline is normalized.
+    autocorrect_priority(1)
+
     def visit_root(root)
       return if document.source.empty?
       line_number = document.last_non_empty_line
@@ -12,14 +18,32 @@ module HamlLint
       node = root.node_for_line(line_number)
       return if node.disabled?(self)
 
-      ends_with_newline = document.source.end_with?("\n")
+      present = config['present'] ? true : false
+      corrected = corrected_source(present)
+      return if document.source == corrected
 
-      if config['present']
-        unless ends_with_newline
-          record_lint(line_number, 'Files should end with a trailing newline')
-        end
-      elsif ends_with_newline
-        record_lint(line_number, 'Files should not end with a trailing newline')
+      record_lint(line_number, message_for(present), corrected: autocorrect?)
+      apply_autocorrect(corrected)
+    end
+
+    private
+
+    def message_for(present)
+      if present
+        'Files should end with a trailing newline'
+      else
+        'Files should not end with a trailing newline'
+      end
+    end
+
+    # Normalizes only the single final newline. Collapsing multiple trailing
+    # newlines is `TrailingEmptyLines`' job, so a file that already ends with a
+    # newline is left untouched here under `present`.
+    def corrected_source(present)
+      if present
+        document.source.end_with?("\n") ? document.source : "#{document.source}\n"
+      else
+        document.source.sub(/\n+\z/, '')
       end
     end
   end

--- a/lib/haml_lint/linter/implicit_div.rb
+++ b/lib/haml_lint/linter/implicit_div.rb
@@ -6,6 +6,8 @@ module HamlLint
   class Linter::ImplicitDiv < Linter
     include LinterRegistry
 
+    supports_autocorrect(true)
+
     def visit_tag(node)
       return unless node.tag_name == 'div'
 
@@ -14,9 +16,20 @@ module HamlLint
       tag = node.source_code[/\s*([^\s={(\[]+)/, 1]
       return unless tag.start_with?('%div')
 
+      corrected = correct_implicit_div(node)
       record_lint(node,
                   "`#{tag}` can be written as `#{node.static_attributes_source}` " \
-                  'since `%div` is implicit')
+                  'since `%div` is implicit',
+                  corrected: corrected)
+    end
+
+    private
+
+    # @return [Boolean]
+    def correct_implicit_div(node)
+      index = node.line - 1
+      line = autocorrected_lines[index]
+      correct_line(index, line.sub(/\A(\s*)%div(?=[.#])/, '\1'))
     end
   end
 end

--- a/lib/haml_lint/linter/leading_comment_space.rb
+++ b/lib/haml_lint/linter/leading_comment_space.rb
@@ -5,12 +5,24 @@ module HamlLint
   class Linter::LeadingCommentSpace < Linter
     include LinterRegistry
 
+    supports_autocorrect(true)
+
     def visit_haml_comment(node)
       # Skip if the node spans multiple lines starting on the second line,
       # or starts with a space
       return if /\A#*(\s*|\s+\S.*)$/.match?(node.text)
 
-      record_lint(node, 'Comment should have a space after the `#`')
+      corrected = correct_leading_space(node)
+      record_lint(node, 'Comment should have a space after the `#`', corrected: corrected)
+    end
+
+    private
+
+    # @return [Boolean]
+    def correct_leading_space(node)
+      index = node.line - 1
+      line = autocorrected_lines[index]
+      correct_line(index, line.sub(/\A(\s*-#+)(?=\S)/, '\1 '))
     end
   end
 end

--- a/lib/haml_lint/linter/multiline_script.rb
+++ b/lib/haml_lint/linter/multiline_script.rb
@@ -5,6 +5,9 @@ module HamlLint
   class Linter::MultilineScript < Linter
     include LinterRegistry
 
+    supports_autocorrect(true)
+    autocorrect_safe(false)
+
     # List of operators that can split a script into two lines that we want to
     # alert on.
     SPLIT_OPERATORS = %w[
@@ -31,7 +34,39 @@ module HamlLint
       check(node)
     end
 
+    def after_visit_root(node)
+      super
+      return if merges.empty?
+
+      apply_autocorrect(merged_source)
+    end
+
     private
+
+    def reset_autocorrect_state
+      super
+      @merges = []
+    end
+
+    def merged_source
+      lines = document.source_lines.dup
+      to_delete = apply_merges(lines)
+      lines.reject.with_index { |_, index| to_delete.include?(index) }.join("\n")
+    end
+
+    # Mutates +lines+ in place, folding each continuation script onto its chain
+    # root, and returns the line indices that should be deleted.
+    #
+    # @return [Array<Integer>]
+    def apply_merges(lines)
+      redirect = {}
+      merges.sort_by { |merge| merge[:from] }.map do |merge|
+        root = redirect.fetch(merge[:from], merge[:from])
+        redirect[merge[:succ_line]] = root
+        lines[root] = "#{lines[root].rstrip} #{merge[:succ_script]}"
+        merge[:succ_line]
+      end
+    end
 
     def check(node)
       # Condition occurs when scripts do not contain nested content, e.g.
@@ -48,11 +83,36 @@ module HamlLint
       return unless node.children.empty?
 
       operator = node.script[/\s+(\S+)\z/, 1]
-      if SPLIT_OPERATORS.include?(operator)
-        record_lint(node,
-                    "Script with trailing operator `#{operator}` should be " \
-                    'merged with the script on the following line')
-      end
+      return unless SPLIT_OPERATORS.include?(operator)
+
+      corrected = collect_merge(node)
+      record_lint(node,
+                  "Script with trailing operator `#{operator}` should be " \
+                  'merged with the script on the following line',
+                  corrected: corrected)
+    end
+
+    def collect_merge(node)
+      return false unless autocorrect?
+
+      # Only merge with the immediately following sibling on the next line.
+      # `node.successor` would climb to an ancestor's sibling when this script is
+      # the last child of its block, which would pull a line from outside the
+      # block into it and change the semantics.
+      succ = node.subsequents.first
+      return false unless succ && %i[script silent_script].include?(succ.type)
+      return false unless succ.line == node.line + 1
+
+      merges << {
+        from: node.line - 1,
+        succ_line: succ.line - 1,
+        succ_script: succ.script.strip,
+      }
+      true
+    end
+
+    def merges
+      @merges ||= []
     end
   end
 end

--- a/lib/haml_lint/linter/ruby_comments.rb
+++ b/lib/haml_lint/linter/ruby_comments.rb
@@ -5,16 +5,26 @@ module HamlLint
   class Linter::RubyComments < Linter
     include LinterRegistry
 
+    supports_autocorrect(true)
+
     def visit_silent_script(node)
-      if code_comment?(node)
-        record_lint(node, 'Use `-#` for comments instead of `- #`')
-      end
+      return unless code_comment?(node)
+
+      corrected = correct_comment(node)
+      record_lint(node, 'Use `-#` for comments instead of `- #`', corrected: corrected)
     end
 
     private
 
     def code_comment?(node)
       node.script =~ /\A\s+#/
+    end
+
+    # @return [Boolean]
+    def correct_comment(node)
+      index = node.line - 1
+      line = autocorrected_lines[index]
+      correct_line(index, line.sub(/\A(\s*)-\s+#/, '\1-#'))
     end
   end
 end

--- a/lib/haml_lint/linter/space_before_script.rb
+++ b/lib/haml_lint/linter/space_before_script.rb
@@ -5,6 +5,8 @@ module HamlLint
   class Linter::SpaceBeforeScript < Linter
     include LinterRegistry
 
+    supports_autocorrect(true)
+
     MESSAGE_FORMAT = 'The %s symbol should have one space separating it from code'
 
     ALLOWED_SEPARATORS = [' ', '#'].freeze
@@ -33,18 +35,23 @@ module HamlLint
       # (need to do it this way as the parser strips whitespace from node)
       return unless tag_with_text[index - 1] != ' '
 
-      record_lint(node, MESSAGE_FORMAT % '=')
+      corrected = correct_inline_script(node, text)
+      record_lint(node, MESSAGE_FORMAT % '=', corrected: corrected)
     end
 
     def visit_script(node)
       # Plain text nodes with interpolation are converted to script nodes, so we
       # need to ignore them here.
       return unless document.source_lines[node.line - 1].lstrip.start_with?('=')
-      record_lint(node, MESSAGE_FORMAT % '=') if missing_space?(node)
+      return unless missing_space?(node)
+
+      record_lint(node, MESSAGE_FORMAT % '=', corrected: correct_leading_marker(node, '='))
     end
 
     def visit_silent_script(node)
-      record_lint(node, MESSAGE_FORMAT % '-') if missing_space?(node)
+      return unless missing_space?(node)
+
+      record_lint(node, MESSAGE_FORMAT % '-', corrected: correct_leading_marker(node, '-'))
     end
 
     private
@@ -52,6 +59,32 @@ module HamlLint
     def missing_space?(node)
       text = node.script
       !ALLOWED_SEPARATORS.include?(text[0]) if text
+    end
+
+    # Inserts one space after a leading `=`/`-` marker.
+    #
+    # @return [Boolean]
+    def correct_leading_marker(node, marker)
+      index = node.line - 1
+      line = autocorrected_lines[index]
+      escaped = Regexp.escape(marker)
+      correct_line(index, line.sub(/\A(\s*#{escaped})(?=[^\s#{escaped}])/, '\1 '))
+    end
+
+    # Inserts a space after the `=` marker introducing a tag's inline script.
+    #
+    # @return [Boolean]
+    def correct_inline_script(node, text)
+      index = node.line - 1
+      line = autocorrected_lines[index]
+
+      pos = line.rindex("=#{text}")
+      if pos.nil? && (unquoted = strip_surrounding_quotes(text))
+        pos = line.rindex("=#{unquoted}")
+      end
+      return false unless pos
+
+      correct_line(index, "#{line[0..pos]} #{line[(pos + 1)..]}")
     end
   end
 end

--- a/lib/haml_lint/linter/space_inside_hash_attributes.rb
+++ b/lib/haml_lint/linter/space_inside_hash_attributes.rb
@@ -6,6 +6,8 @@ module HamlLint
   class Linter::SpaceInsideHashAttributes < Linter
     include LinterRegistry
 
+    supports_autocorrect(true)
+
     STYLE = {
       'no_space' => {
         start_regex: /\A\{[^ ]/,
@@ -24,11 +26,47 @@ module HamlLint
     def visit_tag(node)
       return unless node.hash_attributes?
 
-      style = STYLE[config['style'] == 'no_space' ? 'no_space' : 'space']
+      style_name = config['style'] == 'no_space' ? 'no_space' : 'space'
+      style = STYLE[style_name]
       source = node.hash_attributes_source
 
-      record_lint(node, style[:start_message]) unless source&.match?(style[:start_regex])
-      record_lint(node, style[:end_message]) unless source&.match?(style[:end_regex])
+      start_ok = source.match?(style[:start_regex])
+      end_ok = source.match?(style[:end_regex])
+      return if start_ok && end_ok
+
+      corrected = correct_hash_spacing(node, source, style_name)
+      record_lint(node, style[:start_message], corrected: corrected) unless start_ok
+      record_lint(node, style[:end_message], corrected: corrected) unless end_ok
+    end
+
+    private
+
+    # @return [Boolean]
+    def correct_hash_spacing(node, source, style_name)
+      return false unless source
+      return false if source.include?("\n") # multi-line hash: detection-only
+
+      index = node.line - 1
+      line = autocorrected_lines[index]
+      return false unless line.include?(source)
+
+      fixed = corrected_hash_source(source, style_name)
+      return false if fixed == source
+
+      correct_line(index, line.sub(source) { fixed })
+    end
+
+    # @return [String]
+    def corrected_hash_source(source, style_name)
+      inner = source[1...-1].strip
+
+      if style_name == 'no_space'
+        "{#{inner}}"
+      elsif inner.empty?
+        '{ }'
+      else
+        "{ #{inner} }"
+      end
     end
   end
 end

--- a/lib/haml_lint/linter/tag_name.rb
+++ b/lib/haml_lint/linter/tag_name.rb
@@ -5,11 +5,24 @@ module HamlLint
   class Linter::TagName < Linter
     include LinterRegistry
 
+    supports_autocorrect(true)
+
     def visit_tag(node)
       tag = node.tag_name
       return unless /[A-Z]/.match?(tag)
 
-      record_lint(node, "`#{tag}` should be written in lowercase as `#{tag.downcase}`")
+      corrected = correct_tag_name(node, tag)
+      record_lint(node, "`#{tag}` should be written in lowercase as `#{tag.downcase}`",
+                  corrected: corrected)
+    end
+
+    private
+
+    # @return [Boolean]
+    def correct_tag_name(node, tag)
+      index = node.line - 1
+      line = autocorrected_lines[index]
+      correct_line(index, line.sub(/(%)#{Regexp.escape(tag)}/, "\\1#{tag.downcase}"))
     end
   end
 end

--- a/lib/haml_lint/linter/trailing_empty_lines.rb
+++ b/lib/haml_lint/linter/trailing_empty_lines.rb
@@ -5,6 +5,8 @@ module HamlLint
   class Linter::TrailingEmptyLines < Linter
     include LinterRegistry
 
+    supports_autocorrect(true)
+
     DummyNode = Struct.new(:line)
 
     def visit_root(root)
@@ -16,7 +18,17 @@ module HamlLint
 
       return unless document.source.end_with?("\n\n")
 
-      record_lint(line_number, 'Files should not end with trailing empty lines')
+      record_lint(line_number, 'Files should not end with trailing empty lines',
+                  corrected: autocorrect?)
+
+      apply_autocorrect(corrected_source)
+    end
+
+    private
+
+    def corrected_source
+      last_non_empty_index = document.source_lines.rindex { |line| !line.empty? } || 0
+      "#{document.source_lines[0..last_non_empty_index].join("\n")}\n"
     end
   end
 end

--- a/lib/haml_lint/linter/trailing_whitespace.rb
+++ b/lib/haml_lint/linter/trailing_whitespace.rb
@@ -5,17 +5,30 @@ module HamlLint
   class Linter::TrailingWhitespace < Linter
     include LinterRegistry
 
+    supports_autocorrect(true)
+
     DummyNode = Struct.new(:line)
 
     def visit_root(root)
+      new_lines = document.source_lines.dup
+      changed = false
+
       document.source_lines.each_with_index do |line, index|
         next unless /\s+$/.match?(line)
 
         node = root.node_for_line(index + 1)
-        unless node.disabled?(self)
-          record_lint DummyNode.new(index + 1), 'Line contains trailing whitespace'
+        next if node.disabled?(self)
+
+        if autocorrect?
+          new_lines[index] = line.sub(/\s+$/, '')
+          changed = true
         end
+
+        record_lint(DummyNode.new(index + 1), 'Line contains trailing whitespace',
+                    corrected: autocorrect?)
       end
+
+      apply_autocorrect(new_lines.join("\n")) if changed
     end
   end
 end

--- a/lib/haml_lint/linter/unnecessary_interpolation.rb
+++ b/lib/haml_lint/linter/unnecessary_interpolation.rb
@@ -11,21 +11,48 @@ module HamlLint
   class Linter::UnnecessaryInterpolation < Linter
     include LinterRegistry
 
+    supports_autocorrect(true)
+
     def visit_tag(node)
       return if node.script.length <= 2
 
       count = 0
       chars = 2 # Include surrounding quote chars
-      HamlLint::Utils.extract_interpolated_values(node.script) do |interpolated_code, _line|
+      interpolated_code = nil
+      HamlLint::Utils.extract_interpolated_values(node.script) do |code, _line|
         count += 1
         return if count > 1 # rubocop:disable Lint/NonLocalExitFromIterator
-        chars += interpolated_code.length + 3
+        chars += code.length + 3
+        interpolated_code = code
       end
 
       if chars == node.script.length
+        corrected = correct_interpolation(node, interpolated_code)
         record_lint(node, '`%... \#{expression}` can be written without ' \
-                          'interpolation as `%...= expression`')
+                          'interpolation as `%...= expression`', corrected: corrected)
       end
+    end
+
+    private
+
+    # @return [Boolean]
+    def correct_interpolation(node, interpolated_code)
+      return false unless interpolated_code
+
+      index = node.line - 1
+      line = autocorrected_lines[index]
+      escaped = Regexp.escape(interpolated_code)
+
+      new_line =
+        if inline_content_is_string?(node)
+          line.sub(/=\s*"\#\{#{escaped}\}"\s*\z/, "= #{interpolated_code}")
+        else
+          line.sub(/\s+\#\{#{escaped}\}\s*\z/, "= #{interpolated_code}")
+        end
+
+      return false if new_line == line
+
+      correct_line(index, new_line)
     end
   end
 end

--- a/lib/haml_lint/runner.rb
+++ b/lib/haml_lint/runner.rb
@@ -122,6 +122,9 @@ module HamlLint
       lint_arrays = []
 
       autocorrecting_linters = linters.select(&:supports_autocorrect?)
+                                      .each_with_index
+                                      .sort_by { |linter, index| [linter.class.autocorrect_priority, index] }
+                                      .map(&:first)
       lint_arrays << autocorrecting_linters.map do |linter|
         linter.run(document, autocorrect: @autocorrect)
       end

--- a/spec/haml_lint/linter/class_attribute_with_static_value_spec.rb
+++ b/spec/haml_lint/linter/class_attribute_with_static_value_spec.rb
@@ -85,4 +85,100 @@ describe HamlLint::Linter::ClassAttributeWithStaticValue do
 
     it { should_not report_lint }
   end
+
+  context 'with autocorrect' do
+    let(:autocorrect) { :safe }
+
+    context 'when the class is the only attribute' do
+      let(:haml) { "%tag{ class: 'status' }" }
+
+      it 'moves the class into the inline syntax' do
+        subject
+        document.source.should == '%tag.status'
+      end
+
+      it 'records the lint as corrected' do
+        subject
+        subject.lints.size.should == 1
+        subject.lints.first.corrected.should == true
+      end
+    end
+
+    context 'when the class value is a symbol' do
+      let(:haml) { '%tag{ class: :status }' }
+
+      it 'moves the class into the inline syntax' do
+        subject
+        document.source.should == '%tag.status'
+      end
+    end
+
+    context 'when the tag already has an inline class' do
+      let(:haml) { "%tag.existing{ class: 'status' }" }
+
+      it 'appends the class after the existing inline class' do
+        subject
+        document.source.should == '%tag.existing.status'
+      end
+    end
+
+    context 'when the tag is an implicit div' do
+      let(:haml) { ".foo{ class: 'status' }" }
+
+      it 'appends the class to the implicit div' do
+        subject
+        document.source.should == '.foo.status'
+      end
+    end
+
+    context 'when the hash has other attributes' do
+      let(:haml) { "%tag{ class: 'status', id: 'x' }" }
+
+      it 'reports the lint without correcting' do
+        subject
+        subject.lints.size.should == 1
+        subject.lints.first.corrected.should == false
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the class value duplicates an existing inline class' do
+      let(:haml) { "%tag.status{ class: 'status' }" }
+
+      it 'reports the lint without correcting' do
+        subject
+        subject.lints.first.corrected.should == false
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the hash spans multiple lines' do
+      let(:haml) { "%tag{\n  class: 'status' }" }
+
+      it 'reports the lint without correcting' do
+        subject
+        subject.lints.first.corrected.should == false
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the linter is disabled' do
+      let(:haml) { "-# haml-lint:disable ClassAttributeWithStaticValue\n%tag{ class: 'status' }" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'under :all mode' do
+      let(:autocorrect) { :all }
+      let(:haml) { "%tag{ class: 'status' }" }
+
+      it 'also moves the class into the inline syntax' do
+        subject
+        document.source.should == '%tag.status'
+      end
+    end
+  end
 end

--- a/spec/haml_lint/linter/class_attribute_with_static_value_spec.rb
+++ b/spec/haml_lint/linter/class_attribute_with_static_value_spec.rb
@@ -152,13 +152,16 @@ describe HamlLint::Linter::ClassAttributeWithStaticValue do
       end
     end
 
-    context 'when the hash spans multiple lines' do
-      let(:haml) { "%tag{\n  class: 'status' }" }
+    # Multiline attributes were introduced in 5.2.1
+    if Haml::VERSION >= '5.2.1'
+      context 'when the hash spans multiple lines' do
+        let(:haml) { "%tag{\n  class: 'status' }" }
 
-      it 'reports the lint without correcting' do
-        subject
-        subject.lints.first.corrected.should == false
-        document.source_was_changed.should == false
+        it 'reports the lint without correcting' do
+          subject
+          subject.lints.first.corrected.should == false
+          document.source_was_changed.should == false
+        end
       end
     end
 

--- a/spec/haml_lint/linter/classes_before_ids_spec.rb
+++ b/spec/haml_lint/linter/classes_before_ids_spec.rb
@@ -90,4 +90,81 @@ describe HamlLint::Linter::ClassesBeforeIds do
       )
     end
   end
+
+  context 'with autocorrect' do
+    let(:autocorrect) { :safe }
+
+    context 'when configured with classes first (by default)' do
+      context 'when tag has IDs before classes' do
+        let(:haml) { '#id1#id2#id3.class1.class2.class3' }
+
+        it 'reorders the classes before the IDs' do
+          subject
+          document.source.should == '.class1.class2.class3#id1#id2#id3'
+        end
+
+        it 'records the lint as corrected' do
+          subject
+          subject.lints.size.should == 1
+          subject.lints.first.corrected.should == true
+        end
+      end
+
+      context 'when tag has a class then ID then class' do
+        let(:haml) { '.class1#id.class2' }
+
+        it 'groups all classes before the ID' do
+          subject
+          document.source.should == '.class1.class2#id'
+        end
+      end
+
+      context 'when tag has an ID then class then ID' do
+        let(:haml) { '#id1.class#id2' }
+
+        it 'groups the class before all IDs' do
+          subject
+          document.source.should == '.class#id1#id2'
+        end
+      end
+
+      context 'when tag is already ordered' do
+        let(:haml) { '.class1.class2#id1#id2' }
+
+        it 'does not change the source' do
+          subject
+          document.source_was_changed.should == false
+        end
+      end
+    end
+
+    context 'when configured with ids first' do
+      let(:config) { super().merge('EnforcedStyle' => 'id') }
+      let(:haml) { '.class1.class2.class3#id1#id2#id3' }
+
+      it 'reorders the IDs before the classes' do
+        subject
+        document.source.should == '#id1#id2#id3.class1.class2.class3'
+      end
+    end
+
+    context 'when the linter is disabled inline' do
+      let(:haml) { "-# haml-lint:disable ClassesBeforeIds\n#id.class" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'under :all mode' do
+      let(:autocorrect) { :all }
+      let(:haml) { '#id1#id2#id3.class1.class2.class3' }
+
+      it 'also reorders the classes before the IDs' do
+        subject
+        document.source.should == '.class1.class2.class3#id1#id2#id3'
+      end
+    end
+  end
 end

--- a/spec/haml_lint/linter/consecutive_comments_spec.rb
+++ b/spec/haml_lint/linter/consecutive_comments_spec.rb
@@ -63,4 +63,45 @@ describe HamlLint::Linter::ConsecutiveComments do
       it { should_not report_lint }
     end
   end
+
+  context 'with autocorrect' do
+    context 'under :safe mode (unsafe linter is not applied)' do
+      let(:autocorrect) { :safe }
+      let(:haml) { "-# A collection\n-# of many\n-# consecutive comments" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+
+      it 'records the lint as not corrected' do
+        subject
+        subject.lints.first.corrected.should == false
+      end
+    end
+
+    context 'under :all mode' do
+      let(:autocorrect) { :all }
+      let(:haml) { "-# A collection\n-# of many\n-# consecutive comments" }
+
+      it 'merges them into a single multiline comment' do
+        subject
+        document.source.should == "-# A collection\n   of many\n   consecutive comments"
+      end
+
+      it 'records the lint as corrected' do
+        subject
+        subject.lints.first.corrected.should == true
+      end
+
+      context 'but the linter is disabled in the file' do
+        let(:haml) { "-# haml-lint:disable ConsecutiveComments\n" + super() }
+
+        it 'does not change the source' do
+          subject
+          document.source_was_changed.should == false
+        end
+      end
+    end
+  end
 end

--- a/spec/haml_lint/linter/empty_object_reference_spec.rb
+++ b/spec/haml_lint/linter/empty_object_reference_spec.rb
@@ -32,4 +32,96 @@ describe HamlLint::Linter::EmptyObjectReference do
 
     it { should report_lint }
   end
+
+  context 'with autocorrect' do
+    let(:autocorrect) { :safe }
+
+    context 'when a tag has an empty object reference' do
+      let(:haml) { '%tag[]' }
+
+      it 'removes the empty object reference' do
+        subject
+        document.source.should == '%tag'
+      end
+
+      it 'records the lint as corrected' do
+        subject
+        subject.lints.size.should == 1
+        subject.lints.first.corrected.should == true
+      end
+    end
+
+    context 'when the tag has static classes and ids before the object reference' do
+      let(:haml) { '%tag.foo#bar[]' }
+
+      it 'removes only the empty object reference' do
+        subject
+        document.source.should == '%tag.foo#bar'
+      end
+    end
+
+    context 'when the empty object reference contains whitespace' do
+      let(:haml) { '%tag[ ]' }
+
+      it 'removes the empty object reference' do
+        subject
+        document.source.should == '%tag'
+      end
+    end
+
+    context 'when the tag content contains brackets' do
+      let(:haml) { '%tag[]= foo[]' }
+
+      it 'removes only the object reference, not the content brackets' do
+        subject
+        document.source.should == '%tag= foo[]'
+      end
+    end
+
+    context 'when an attribute hash follows the object reference' do
+      let(:haml) { '%div[]{a: 1}' }
+
+      it 'removes only the object reference' do
+        subject
+        document.source.should == '%div{a: 1}'
+      end
+    end
+
+    context 'when the tag is an implicit div' do
+      let(:haml) { '.foo[]' }
+
+      it 'removes the empty object reference' do
+        subject
+        document.source.should == '.foo'
+      end
+    end
+
+    context 'when the object reference is not empty' do
+      let(:haml) { '%tag[@user]' }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the linter is disabled inline' do
+      let(:haml) { "-# haml-lint:disable EmptyObjectReference\n%tag[]" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'under :all mode' do
+      let(:autocorrect) { :all }
+      let(:haml) { '%tag[]' }
+
+      it 'also removes the empty object reference' do
+        subject
+        document.source.should == '%tag'
+      end
+    end
+  end
 end

--- a/spec/haml_lint/linter/empty_script_spec.rb
+++ b/spec/haml_lint/linter/empty_script_spec.rb
@@ -14,4 +14,49 @@ describe HamlLint::Linter::EmptyScript do
 
     it { should report_lint }
   end
+
+  context 'with autocorrect' do
+    context 'under :safe mode (unsafe linter is not applied)' do
+      let(:autocorrect) { :safe }
+      let(:haml) { "%p One\n-\n%p Two" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+
+      it 'records the lint as not corrected' do
+        subject
+        subject.lints.size.should == 1
+        subject.lints.first.corrected.should == false
+      end
+    end
+
+    context 'under :all mode' do
+      let(:autocorrect) { :all }
+
+      context 'when a bare silent script is on its own line' do
+        let(:haml) { "%p One\n-\n%p Two" }
+
+        it 'removes the empty script line' do
+          subject
+          document.source.should == "%p One\n%p Two"
+        end
+
+        it 'records the lint as corrected' do
+          subject
+          subject.lints.first.corrected.should == true
+        end
+      end
+
+      context 'when the linter is disabled in the file' do
+        let(:haml) { "-# haml-lint:disable EmptyScript\n%p One\n-\n%p Two" }
+
+        it 'does not change the source' do
+          subject
+          document.source_was_changed.should == false
+        end
+      end
+    end
+  end
 end

--- a/spec/haml_lint/linter/final_newline_spec.rb
+++ b/spec/haml_lint/linter/final_newline_spec.rb
@@ -29,6 +29,14 @@ describe HamlLint::Linter::FinalNewline do
         it { should_not report_lint }
       end
     end
+
+    context 'when the file ends with multiple newlines' do
+      let(:haml) { "%span\n\n\n" }
+
+      # The file already ends with a trailing newline,
+      # so FinalNewline is satisfied
+      it { should_not report_lint }
+    end
   end
 
   context 'when no trailing newline is preferred' do
@@ -56,6 +64,101 @@ describe HamlLint::Linter::FinalNewline do
       let(:haml) { '%span' }
 
       it { should_not report_lint }
+    end
+  end
+
+  context 'with autocorrect' do
+    let(:autocorrect) { :safe }
+
+    context 'when a trailing newline is preferred' do
+      let(:config) { super().merge('present' => true) }
+
+      context 'and the file is missing the final newline' do
+        let(:haml) { '%span' }
+
+        it 'appends a single newline' do
+          subject
+          document.source.should == "%span\n"
+        end
+
+        it 'records the lint as corrected' do
+          subject
+          subject.lints.size.should == 1
+          subject.lints.first.corrected.should == true
+        end
+      end
+
+      context 'and the file already ends with a newline' do
+        let(:haml) { "%span\n" }
+
+        it 'does not change the source' do
+          subject
+          document.source_was_changed.should == false
+        end
+      end
+
+      context 'and the file ends with multiple newlines' do
+        let(:haml) { "%span\n\n\n" }
+
+        it 'leaves the extra newlines for other lint to handle' do
+          subject
+          document.source_was_changed.should == false
+        end
+      end
+
+      context 'and the file is empty' do
+        let(:haml) { '' }
+
+        it 'does not change the source' do
+          subject
+          document.source_was_changed.should == false
+        end
+      end
+
+      context 'and the linter is disabled' do
+        let(:haml) { "-# haml-lint:disable FinalNewline\n%span" }
+
+        it 'does not change the source' do
+          subject
+          document.source_was_changed.should == false
+        end
+      end
+    end
+
+    context 'when no trailing newline is preferred' do
+      let(:config) { super().merge('present' => false) }
+
+      context 'and the file ends with a newline' do
+        let(:haml) { "%span\n" }
+
+        it 'removes the final newline' do
+          subject
+          document.source.should == '%span'
+        end
+
+        it 'records the lint as corrected' do
+          subject
+          subject.lints.first.corrected.should == true
+        end
+      end
+
+      context 'and the file does not end with a newline' do
+        let(:haml) { '%span' }
+
+        it 'does not change the source' do
+          subject
+          document.source_was_changed.should == false
+        end
+      end
+
+      context 'and the file ends with multiple newlines' do
+        let(:haml) { "%span\n\n\n" }
+
+        it 'removes all of the trailing newlines' do
+          subject
+          document.source.should == '%span'
+        end
+      end
     end
   end
 end

--- a/spec/haml_lint/linter/implicit_div_spec.rb
+++ b/spec/haml_lint/linter/implicit_div_spec.rb
@@ -68,4 +68,82 @@ describe HamlLint::Linter::ImplicitDiv do
 
     it { should_not report_lint }
   end
+
+  context 'with autocorrect' do
+    let(:autocorrect) { :safe }
+
+    context 'when a div tag has a class' do
+      let(:haml) { '%div.container Hello' }
+
+      it 'removes the implicit div' do
+        subject
+        document.source.should == '.container Hello'
+      end
+
+      it 'records the lint as corrected' do
+        subject
+        subject.lints.size.should == 1
+        subject.lints.first.corrected.should == true
+      end
+    end
+
+    context 'when a div tag has an ID' do
+      let(:haml) { '%div#container Hello' }
+
+      it 'removes the implicit div' do
+        subject
+        document.source.should == '#container Hello'
+      end
+    end
+
+    context 'when a div tag has classes, an ID and content' do
+      let(:haml) { '%div.foo#bar Hello' }
+
+      it 'removes only the implicit div, preserving classes, ID and content' do
+        subject
+        document.source.should == '.foo#bar Hello'
+      end
+    end
+
+    context 'when the div is nested' do
+      let(:haml) { <<-HAML }
+        %tag
+          %child
+            %div.container
+      HAML
+
+      it 'removes the implicit div while preserving indentation' do
+        subject
+        document.source.should == "%tag\n  %child\n    .container\n"
+      end
+    end
+
+    context 'when there is no explicit div to remove' do
+      let(:haml) { '.container Hello' }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the linter is disabled' do
+      let(:haml) { "-# haml-lint:disable ImplicitDiv\n%div.foo" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'under :all mode' do
+      let(:autocorrect) { :all }
+      let(:haml) { '%div.container Hello' }
+
+      it 'also removes the implicit div' do
+        subject
+        document.source.should == '.container Hello'
+      end
+    end
+  end
 end

--- a/spec/haml_lint/linter/leading_comment_space_spec.rb
+++ b/spec/haml_lint/linter/leading_comment_space_spec.rb
@@ -46,4 +46,60 @@ describe HamlLint::Linter::LeadingCommentSpace do
 
     it { should_not report_lint }
   end
+
+  context 'with autocorrect' do
+    let(:autocorrect) { :safe }
+
+    context 'when a comment has no leading space' do
+      let(:haml) { '-#A comment with no space' }
+
+      it 'inserts a space after the marker' do
+        subject
+        document.source.should == '-# A comment with no space'
+      end
+
+      it 'records the lint as corrected' do
+        subject
+        subject.lints.size.should == 1
+        subject.lints.first.corrected.should == true
+      end
+    end
+
+    context 'when a comment uses multiple `#` without a space' do
+      let(:haml) { '-##A comment' }
+
+      it 'inserts a space after the last marker' do
+        subject
+        document.source.should == '-## A comment'
+      end
+    end
+
+    context 'when a comment already has a leading space' do
+      let(:haml) { '-# A comment' }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the linter is disabled' do
+      let(:haml) { "-# haml-lint:disable LeadingCommentSpace\n-#A comment" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'under :all mode' do
+      let(:autocorrect) { :all }
+      let(:haml) { '-#A comment' }
+
+      it 'also inserts a space' do
+        subject
+        document.source.should == '-# A comment'
+      end
+    end
+  end
 end

--- a/spec/haml_lint/linter/multiline_script_spec.rb
+++ b/spec/haml_lint/linter/multiline_script_spec.rb
@@ -42,4 +42,76 @@ describe HamlLint::Linter::MultilineScript do
 
     it { should_not report_lint }
   end
+
+  context 'with autocorrect' do
+    context 'under :safe mode (unsafe linter is not applied)' do
+      let(:autocorrect) { :safe }
+      let(:haml) { "= 1 +\n= 2" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+
+      it 'records the lint as not corrected' do
+        subject
+        subject.lints.first.corrected.should == false
+      end
+    end
+
+    context 'under :all mode' do
+      let(:autocorrect) { :all }
+
+      context 'when a binary operator splits a script' do
+        let(:haml) { "= 1 +\n= 2" }
+
+        it 'merges the two lines' do
+          subject
+          document.source.should == '= 1 + 2'
+        end
+
+        it 'records the lint as corrected' do
+          subject
+          subject.lints.first.corrected.should == true
+        end
+      end
+
+      context 'when a silent script with a child is split' do
+        let(:haml) { "- if condition ||\n- true\n  Result" }
+
+        it 'merges the continuation and keeps the child nested' do
+          subject
+          document.source.should == "- if condition || true\n  Result"
+        end
+      end
+
+      context 'when a chain of operators spans multiple lines' do
+        let(:haml) { "- if a ||\n- b &&\n- c" }
+
+        it 'merges the whole chain onto the root line' do
+          subject
+          document.source.should == '- if a || b && c'
+        end
+      end
+
+      context 'when the trailing operator is the last node of a block' do
+        let(:haml) { "- if x\n  - foo &&\n- bar" }
+
+        it 'reports the lint but does not merge across the block boundary' do
+          subject
+          subject.lints.size.should == 1
+          document.source_was_changed.should == false
+        end
+      end
+
+      context 'when the linter is disabled in the file' do
+        let(:haml) { "-# haml-lint:disable MultilineScript\n= 1 +\n= 2" }
+
+        it 'does not change the source' do
+          subject
+          document.source_was_changed.should == false
+        end
+      end
+    end
+  end
 end

--- a/spec/haml_lint/linter/ruby_comments_spec.rb
+++ b/spec/haml_lint/linter/ruby_comments_spec.rb
@@ -14,4 +14,60 @@ describe HamlLint::Linter::RubyComments do
 
     it { should report_lint }
   end
+
+  context 'with autocorrect' do
+    let(:autocorrect) { :safe }
+
+    context 'when a Ruby comment is used' do
+      let(:haml) { '- # A Ruby comment' }
+
+      it 'rewrites it as a HAML comment' do
+        subject
+        document.source.should == '-# A Ruby comment'
+      end
+
+      it 'records the lint as corrected' do
+        subject
+        subject.lints.size.should == 1
+        subject.lints.first.corrected.should == true
+      end
+    end
+
+    context 'when there are several spaces before the `#`' do
+      let(:haml) { '-   # A Ruby comment' }
+
+      it 'collapses to the HAML comment marker' do
+        subject
+        document.source.should == '-# A Ruby comment'
+      end
+    end
+
+    context 'when a HAML comment is already used' do
+      let(:haml) { '-# A HAML comment' }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the linter is disabled' do
+      let(:haml) { "-# haml-lint:disable RubyComments\n- # A Ruby comment" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'under :all mode' do
+      let(:autocorrect) { :all }
+      let(:haml) { '- # A Ruby comment' }
+
+      it 'also rewrites the comment' do
+        subject
+        document.source.should == '-# A Ruby comment'
+      end
+    end
+  end
 end

--- a/spec/haml_lint/linter/space_before_script_spec.rb
+++ b/spec/haml_lint/linter/space_before_script_spec.rb
@@ -179,4 +179,87 @@ describe HamlLint::Linter::SpaceBeforeScript do
       it { should_not report_lint }
     end
   end
+
+  context 'with autocorrect' do
+    let(:autocorrect) { :safe }
+
+    context 'when a silent script has no separating space' do
+      let(:haml) { '-some_code' }
+
+      it 'inserts a space after the `-`' do
+        subject
+        document.source.should == '- some_code'
+      end
+
+      it 'records the lint as corrected' do
+        subject
+        subject.lints.first.corrected.should == true
+      end
+    end
+
+    context 'when an output script has no separating space' do
+      let(:haml) { '=some_code' }
+
+      it 'inserts a space after the `=`' do
+        subject
+        document.source.should == '= some_code'
+      end
+    end
+
+    context 'when an inline tag script has no separating space' do
+      let(:haml) { "%span='there'" }
+
+      it 'inserts a space after the `=`' do
+        subject
+        document.source.should == "%span= 'there'"
+      end
+    end
+
+    context 'when an inline tag script with interpolation has no separating space' do
+      let(:haml) { '%p="Some #{interpolated} text"' }
+
+      it 'inserts a space after the `=`' do
+        subject
+        document.source.should == '%p= "Some #{interpolated} text"'
+      end
+    end
+
+    context 'when the script already has a separating space' do
+      let(:haml) { '= some_code' }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the linter is disabled' do
+      let(:haml) { "-# haml-lint:disable SpaceBeforeScript\n=some_code" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when an inline script spreads across multiple lines via comma' do
+      let(:haml) { "%tag=link_to 'Link',\n             path\n%tag" }
+
+      it 'reports the lint without correcting it' do
+        subject
+        document.source_was_changed.should == false
+        subject.lints.first.corrected.should == false
+      end
+    end
+
+    context 'under :all mode' do
+      let(:autocorrect) { :all }
+      let(:haml) { '=some_code' }
+
+      it 'also inserts a space' do
+        subject
+        document.source.should == '= some_code'
+      end
+    end
+  end
 end

--- a/spec/haml_lint/linter/space_inside_hash_attributes_spec.rb
+++ b/spec/haml_lint/linter/space_inside_hash_attributes_spec.rb
@@ -213,4 +213,93 @@ describe HamlLint::Linter::SpaceInsideHashAttributes do
       end
     end
   end
+
+  context 'with autocorrect' do
+    let(:autocorrect) { :safe }
+
+    context 'default config (space)' do
+      context 'when the braces have no padding' do
+        let(:haml) { "%tag{lang: 'en'}" }
+
+        it 'adds a space inside both braces' do
+          subject
+          document.source.should == "%tag{ lang: 'en' }"
+        end
+
+        it 'records the lints as corrected' do
+          subject
+          subject.lints.map(&:corrected).should == [true, true]
+        end
+      end
+
+      context 'when only the trailing space is missing' do
+        let(:haml) { "%tag{ lang: 'en'}" }
+
+        it 'adds the missing trailing space only' do
+          subject
+          document.source.should == "%tag{ lang: 'en' }"
+          subject.lints.size.should == 1
+        end
+      end
+
+      context 'when there is extra padding' do
+        let(:haml) { "%tag{  lang: 'en'  }" }
+
+        it 'collapses to a single space inside each brace' do
+          subject
+          document.source.should == "%tag{ lang: 'en' }"
+        end
+      end
+    end
+
+    context 'with no_space config' do
+      let(:config) { super().merge('style' => 'no_space') }
+      let(:haml) { "%tag{ lang: 'en' }" }
+
+      it 'removes the padding inside the braces' do
+        subject
+        document.source.should == "%tag{lang: 'en'}"
+      end
+    end
+
+    context 'when already in the desired style' do
+      let(:haml) { "%tag{ lang: 'en' }" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the linter is disabled' do
+      let(:haml) { "-# haml-lint:disable SpaceInsideHashAttributes\n%tag{lang: 'en'}" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    if Haml::VERSION >= '5.2.1'
+      context 'when the hash spans multiple lines' do
+        let(:haml) { "%tag{lang: 'en',\n  near: true}" }
+
+        it 'reports the lint without correcting it' do
+          subject
+          document.source_was_changed.should == false
+          subject.lints.first.corrected.should == false
+        end
+      end
+    end
+
+    context 'under :all mode' do
+      let(:autocorrect) { :all }
+      let(:haml) { "%tag{lang: 'en'}" }
+
+      it 'also normalizes the padding' do
+        subject
+        document.source.should == "%tag{ lang: 'en' }"
+      end
+    end
+  end
 end

--- a/spec/haml_lint/linter/tag_name_spec.rb
+++ b/spec/haml_lint/linter/tag_name_spec.rb
@@ -22,4 +22,60 @@ describe HamlLint::Linter::TagName do
     let(:haml) { '%some_tag' }
     it { should_not report_lint }
   end
+
+  context 'with autocorrect' do
+    let(:autocorrect) { :safe }
+
+    context 'when a tag is all uppercase' do
+      let(:haml) { '%BODY' }
+
+      it 'downcases the tag name' do
+        subject
+        document.source.should == '%body'
+      end
+
+      it 'records the lint as corrected' do
+        subject
+        subject.lints.size.should == 1
+        subject.lints.first.corrected.should == true
+      end
+    end
+
+    context 'when a mixed-case tag has attributes and content' do
+      let(:haml) { '%MyDiv.foo#bar Hello' }
+
+      it 'downcases only the tag name' do
+        subject
+        document.source.should == '%mydiv.foo#bar Hello'
+      end
+    end
+
+    context 'when the tag is already lowercase' do
+      let(:haml) { '%div' }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the linter is disabled' do
+      let(:haml) { "-# haml-lint:disable TagName\n%DIV" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'under :all mode' do
+      let(:autocorrect) { :all }
+      let(:haml) { '%DIV' }
+
+      it 'also downcases the tag name' do
+        subject
+        document.source.should == '%div'
+      end
+    end
+  end
 end

--- a/spec/haml_lint/linter/trailing_empty_lines_spec.rb
+++ b/spec/haml_lint/linter/trailing_empty_lines_spec.rb
@@ -26,4 +26,60 @@ describe HamlLint::Linter::TrailingEmptyLines do
       it { should_not report_lint }
     end
   end
+
+  context 'with autocorrect' do
+    let(:autocorrect) { :safe }
+
+    context 'when the file has one trailing blank line' do
+      let(:haml) { "%h1 Hello\n\n" }
+
+      it 'collapses to a single trailing newline' do
+        subject
+        document.source.should == "%h1 Hello\n"
+      end
+
+      it 'records the lint as corrected' do
+        subject
+        subject.lints.size.should == 1
+        subject.lints.first.corrected.should == true
+      end
+    end
+
+    context 'when the file has several trailing blank lines' do
+      let(:haml) { "%h1 Hello\n\n\n\n" }
+
+      it 'collapses to a single trailing newline' do
+        subject
+        document.source.should == "%h1 Hello\n"
+        document.source_was_changed.should == true
+      end
+    end
+
+    context 'when the file has no trailing blank lines' do
+      let(:haml) { "%h1 Hello\n" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the file is empty' do
+      let(:haml) { '' }
+
+      it 'does not change the source and does not crash' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the linter is disabled' do
+      let(:haml) { "-# haml-lint:disable TrailingEmptyLines\n%h1 Hello\n\n" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+  end
 end

--- a/spec/haml_lint/linter/trailing_whitespace_spec.rb
+++ b/spec/haml_lint/linter/trailing_whitespace_spec.rb
@@ -51,4 +51,87 @@ describe HamlLint::Linter::TrailingWhitespace do
 
     it { should_not report_lint }
   end
+
+  context 'with autocorrect' do
+    let(:autocorrect) { :safe }
+
+    context 'when lines contain trailing spaces and tabs' do
+      let(:haml) { "%p Hello   \n%p\tWorld\t" }
+
+      it 'strips the trailing whitespace' do
+        subject
+        document.source.should == "%p Hello\n%p\tWorld"
+      end
+
+      it 'records the lints as corrected' do
+        subject
+        subject.lints.size.should == 2
+        subject.lints.map(&:corrected).should == [true, true]
+      end
+
+      it 'marks the document as changed' do
+        subject
+        document.source_was_changed.should == true
+      end
+    end
+
+    context 'when a line is disabled via directive' do
+      let(:haml) { "-# haml-lint:disable TrailingWhitespace\n%p keep me   " }
+
+      it 'does not strip the disabled line' do
+        subject
+        document.source.should == "-# haml-lint:disable TrailingWhitespace\n%p keep me   "
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the file is already clean' do
+      let(:haml) { "%p Hello\n%p World\n" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when trailing whitespace is inside a filter block' do
+      let(:haml) do
+        [
+          ':plain',
+          '  some text   ',
+          '  more text'
+        ].join("\n")
+      end
+
+      it 'strips the trailing whitespace inside the filter' do
+        subject
+        document.source.should == ":plain\n  some text\n  more text"
+      end
+    end
+
+    context 'under :all mode' do
+      let(:autocorrect) { :all }
+      let(:haml) { '%p Hello   ' }
+
+      it 'also strips the trailing whitespace' do
+        subject
+        document.source.should == '%p Hello'
+      end
+    end
+
+    context 'when the document has stripped frontmatter' do
+      let(:options) do
+        super().merge(config: super()[:config].merge(
+          HamlLint::Configuration.new('skip_frontmatter' => true)
+        ))
+      end
+      let(:haml) { "---\ntitle: x\n---\n%p hello   \n" }
+
+      it 'corrects compatibly with the stripped frontmatter' do
+        subject
+        document.source_was_changed.should == true
+        document.source.should == "\n\n\n%p hello\n"
+      end
+    end
+  end
 end

--- a/spec/haml_lint/linter/unnecessary_interpolation_spec.rb
+++ b/spec/haml_lint/linter/unnecessary_interpolation_spec.rb
@@ -35,4 +35,96 @@ describe HamlLint::Linter::UnnecessaryInterpolation do
     let(:haml) { '%tag= ab' }
     it { should_not report_lint }
   end
+
+  context 'with autocorrect' do
+    let(:autocorrect) { :safe }
+
+    context 'when the tag content is a single interpolation' do
+      let(:haml) { '%tag #{foo}' }
+
+      it 'rewrites it as inline script' do
+        subject
+        document.source.should == '%tag= foo'
+      end
+
+      it 'records the lint as corrected' do
+        subject
+        subject.lints.size.should == 1
+        subject.lints.first.corrected.should == true
+      end
+    end
+
+    context 'when the tag has static classes and ids' do
+      let(:haml) { '%tag.cls#id #{foo}' }
+
+      it 'rewrites it as inline script' do
+        subject
+        document.source.should == '%tag.cls#id= foo'
+      end
+    end
+
+    context 'when the tag has an attribute hash' do
+      let(:haml) { '%tag{a: 1} #{foo}' }
+
+      it 'rewrites it as inline script' do
+        subject
+        document.source.should == '%tag{a: 1}= foo'
+      end
+    end
+
+    context 'when the interpolation expression contains a method call' do
+      let(:haml) { '%tag #{user.name}' }
+
+      it 'preserves the expression' do
+        subject
+        document.source.should == '%tag= user.name'
+      end
+    end
+
+    context 'when the interpolation expression contains quoted characters' do
+      let(:haml) { "%tag \#{t('.x')}" }
+
+      it 'preserves the expression' do
+        subject
+        document.source.should == "%tag= t('.x')"
+      end
+    end
+
+    context 'when the content is an explicit pure-interpolation string' do
+      let(:haml) { '%tag= "#{foo}"' }
+
+      it 'rewrites it without the interpolation wrapper' do
+        subject
+        document.source.should == '%tag= foo'
+      end
+    end
+
+    context 'when the tag has mixed inline content' do
+      let(:haml) { '%tag Some #{x} text' }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the linter is disabled inline' do
+      let(:haml) { "-# haml-lint:disable UnnecessaryInterpolation\n%tag \#{foo}" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'under :all mode' do
+      let(:autocorrect) { :all }
+      let(:haml) { '%tag #{foo}' }
+
+      it 'also rewrites it as inline script' do
+        subject
+        document.source.should == '%tag= foo'
+      end
+    end
+  end
 end

--- a/spec/haml_lint/linter_spec.rb
+++ b/spec/haml_lint/linter_spec.rb
@@ -45,6 +45,92 @@ describe HamlLint::Linter do
     end
   end
 
+  describe 'autocorrect safety gate' do
+    let(:options) do
+      {
+        config: HamlLint::ConfigurationLoader.default_configuration,
+        file: 'file.haml',
+      }
+    end
+
+    # A linter whose only job is to rewrite the document to a marker string when
+    # its safety gate permits, so we can observe whether a correction was applied.
+    def gated_linter_class(safe:)
+      Class.new(HamlLint::Linter) do
+        supports_autocorrect(true)
+        autocorrect_safe(safe)
+
+        def visit_root(_root)
+          record_lint(1, 'Needs correcting', corrected: autocorrect?)
+          apply_autocorrect('%p corrected')
+        end
+      end
+    end
+
+    let(:document) { HamlLint::Document.new('%p original', options) }
+
+    def run_linter(safe:, autocorrect:)
+      linter = gated_linter_class(safe: safe).new(config)
+      linter.run(document, autocorrect: autocorrect)
+      linter
+    end
+
+    context 'a safe linter' do
+      it 'applies the correction under :safe' do
+        run_linter(safe: true, autocorrect: :safe)
+        document.source.should == '%p corrected'
+        document.source_was_changed.should == true
+      end
+
+      it 'applies the correction under :all' do
+        run_linter(safe: true, autocorrect: :all)
+        document.source.should == '%p corrected'
+        document.source_was_changed.should == true
+      end
+    end
+
+    context 'an unsafe linter' do
+      it 'does not change the source under :safe' do
+        linter = run_linter(safe: false, autocorrect: :safe)
+        document.source.should == '%p original'
+        document.source_was_changed.should == false
+        linter.lints.first.corrected.should == false
+      end
+
+      it 'applies the correction under :all' do
+        run_linter(safe: false, autocorrect: :all)
+        document.source.should == '%p corrected'
+        document.source_was_changed.should == true
+      end
+    end
+
+    context 'with no autocorrect mode' do
+      it 'never changes the source' do
+        run_linter(safe: true, autocorrect: nil)
+        document.source.should == '%p original'
+        document.source_was_changed.should == false
+      end
+    end
+  end
+
+  describe '.autocorrect_priority' do
+    it 'defaults to 0 when never declared' do
+      linter_class = Class.new(HamlLint::Linter)
+      linter_class.autocorrect_priority.should == 0
+    end
+
+    it 'returns the value declared in the linter body' do
+      linter_class = Class.new(HamlLint::Linter) do
+        autocorrect_priority(5)
+      end
+      linter_class.autocorrect_priority.should == 5
+    end
+
+    it 'declares FinalNewline to run after the default linters' do
+      HamlLint::Linter::FinalNewline.autocorrect_priority.should be > 0
+    end
+  end
+
   describe '#name' do
     subject { linter.name }
 

--- a/spec/haml_lint/runner_spec.rb
+++ b/spec/haml_lint/runner_spec.rb
@@ -84,7 +84,7 @@ describe HamlLint::Runner do
         before do
           runner.unstub(:extract_applicable_sources)
           runner.unstub(:collect_lints)
-          `echo "%div{ class:    'foo' } hello" > example.haml`
+          `echo "%div{ class:    'foo', id: 'x' } hello" > example.haml`
         end
 
         it 'warms up the cache in parallel' do
@@ -102,7 +102,7 @@ describe HamlLint::Runner do
 
             it 'successfully fixes those errors' do
               expect(subject.lints.detect(&:corrected).message).to match(/Unnecessary spacing detected./)
-              expect(File.read('example.haml')).to eq("%div{ class: 'foo' } hello\n")
+              expect(File.read('example.haml')).to eq("%div{ class: 'foo', id: 'x' } hello\n")
             end
           end
         end
@@ -168,6 +168,154 @@ describe HamlLint::Runner do
       end
     end
 
+    context 'with the source-level linters and autocorrect' do
+      let(:source_linters) { %w[TrailingWhitespace TrailingEmptyLines FinalNewline] }
+      let(:options) do
+        base_options.merge(files: %w[example.haml], included_linters: source_linters,
+                           autocorrect: autocorrect)
+      end
+      let(:autocorrect) { :safe }
+
+      include_context 'isolated environment'
+
+      before do
+        File.write('example.haml', "%p hello   \n%p world\t\n\n\n")
+      end
+
+      it 'fixes trailing whitespace and trailing empty lines in one run' do
+        subject
+        File.read('example.haml').should == "%p hello\n%p world\n"
+      end
+
+      it 'reports the corrected offenses' do
+        subject.lints.all?(&:corrected).should == true
+        subject.lints.size.should be >= 1
+      end
+
+      context 'under :all mode' do
+        let(:autocorrect) { :all }
+
+        it 'fixes the file the same way' do
+          subject
+          File.read('example.haml').should == "%p hello\n%p world\n"
+        end
+      end
+
+      context 'when a final newline is missing' do
+        before { File.write('example.haml', '%p hello   ') }
+
+        it 'strips whitespace and adds the final newline' do
+          subject
+          File.read('example.haml').should == "%p hello\n"
+        end
+      end
+
+      context 'with --auto-correct-only' do
+        let(:options) { super().merge(autocorrect_only: true) }
+
+        it 'rewrites the file and only reports corrected lints' do
+          subject
+          File.read('example.haml').should == "%p hello\n%p world\n"
+          subject.lints.all?(&:corrected).should == true
+        end
+      end
+
+      context 'when both FinalNewline and TrailingEmptyLines would act' do
+        before { File.write('example.haml', "%p hello\n\n\n") }
+
+        it 'leaves exactly one final newline and no trailing blank lines' do
+          subject
+          File.read('example.haml').should == "%p hello\n"
+        end
+      end
+
+      context 'even when FinalNewline is listed before the others' do
+        let(:source_linters) { %w[FinalNewline TrailingEmptyLines TrailingWhitespace] }
+
+        it 'applies FinalNewline last, keeping the other linters in order' do
+          invoked = []
+          source_linters.each do |name|
+            klass = HamlLint::Linter.const_get(name)
+            klass.any_instance.stub(:run).and_wrap_original do |original, *args, **kwargs|
+              invoked << name if kwargs.key?(:autocorrect)
+              original.call(*args, **kwargs)
+            end
+          end
+
+          subject
+
+          invoked.should == %w[TrailingEmptyLines TrailingWhitespace FinalNewline]
+        end
+      end
+    end
+
+    context 'with autocorrect across multiple files' do
+      # Linter instances are reused across files, so per-run autocorrect state
+      # must be reset between files. Otherwise a corrected file leaks its content
+      # into the next file processed by the same linter instance.
+      let(:options) do
+        base_options.merge(files: %w[a_dirty.haml b_clean.haml],
+                           included_linters: %w[TagName], autocorrect: :safe)
+      end
+
+      include_context 'isolated environment'
+
+      before do
+        File.write('a_dirty.haml', "%DIV foo\n")
+        File.write('b_clean.haml', "%span bar\n")
+      end
+
+      it 'corrects each file without leaking content between them' do
+        subject
+        File.read('a_dirty.haml').should == "%div foo\n"
+        File.read('b_clean.haml').should == "%span bar\n"
+      end
+    end
+
+    context 'with MultilineScript autocorrect across multiple files' do
+      # MultilineScript accumulates pending merges in instance state; that state
+      # must be reset between files, or the merge from a_dirty leaks into b_clean.
+      let(:options) do
+        base_options.merge(files: %w[a_dirty.haml b_clean.haml],
+                           included_linters: %w[MultilineScript], autocorrect: :all)
+      end
+
+      include_context 'isolated environment'
+
+      before do
+        File.write('a_dirty.haml', "- foo ||\n- bar\n")
+        File.write('b_clean.haml', "%p clean\n%p second\n")
+      end
+
+      it 'merges only the dirty file and leaves the clean file intact' do
+        subject
+        File.read('a_dirty.haml').should == "- foo || bar\n"
+        File.read('b_clean.haml').should == "%p clean\n%p second\n"
+      end
+    end
+
+    context 'with EmptyScript autocorrect across multiple files' do
+      # EmptyScript accumulates the lines to delete in instance state; that state
+      # must be reset between files, or a_dirty's deletion leaks into b_clean.
+      let(:options) do
+        base_options.merge(files: %w[a_dirty.haml b_clean.haml],
+                           included_linters: %w[EmptyScript], autocorrect: :all)
+      end
+
+      include_context 'isolated environment'
+
+      before do
+        File.write('a_dirty.haml', "- foo\n-\n")
+        File.write('b_clean.haml', "%p one\n%p two\n%p three\n")
+      end
+
+      it 'deletes only in the dirty file and leaves the clean file intact' do
+        subject
+        File.read('a_dirty.haml').should == "- foo\n"
+        File.read('b_clean.haml').should == "%p one\n%p two\n%p three\n"
+      end
+    end
+
     context 'with the stdin option' do
       let(:options) { base_options.merge(stdin: 'test.html.haml') }
       let(:stdin) { +"= \"Single-quoted strings offense\".capitalize\n" }
@@ -195,6 +343,19 @@ describe HamlLint::Runner do
         subject.lints.first.filename.should == 'test.html.haml'
         subject.lints.first.message.should match(/Prefer single-quoted strings/)
         $stdout.should have_received(:write).with("= 'Single-quoted strings offense'.capitalize\n")
+      end
+
+      context 'for a source-level linter' do
+        let(:options) do
+          base_options.merge(stdin: 'test.html.haml', stderr: true, autocorrect: :safe,
+                             included_linters: %w[TrailingWhitespace])
+        end
+        let(:stdin) { +"%p hello   \n" }
+
+        it 'writes the corrected source to stdout' do
+          subject.lints.first.corrected.should == true
+          $stdout.should have_received(:write).with("%p hello\n")
+        end
       end
     end
   end


### PR DESCRIPTION
Closes #524 

## Add auto-correction to HAML-level linters

### Summary

Until now, auto-correction in haml-lint was limited to the embedded Ruby code handled through the RuboCop round-trip. This PR brings auto-correction to the **HAML-level linters** themselves, so `-a`/`--auto-correct` and `-A`/`--auto-correct-all` can now fix HAML syntax and style issues directly in the template.

It adds the shared infrastructure on the `Linter` base class and wires up 16 linters to correct what they flag.

### What's included

**Base infrastructure (`lib/haml_lint/linter.rb`)**

- `autocorrect?`: resolves the active mode (`:safe`, `:all`, or `nil`) against each linter's declared safety.
- Per-line correction helpers: `autocorrected_lines` (a lazy working copy of the source) and `correct_line(index, text)`, which buffer edits during the tree walk and flush once via `after_visit_root` into `Document#change_source`. Editing a copy avoids reparsing the tree mid-traversal.
- `apply_autocorrect(new_source)`: the single mutation path for whole-document corrections, routed through `Document#change_source` (which reparses and rolls back if the result isn't valid HAML).
- `autocorrect_safe(false)`: lets a linter declare its correction **unsafe**, so it only runs under `-A`/`--auto-correct-all`. Default is safe.
- `autocorrect_priority(n)`: controls relative ordering when one correction depends on another having already run (all corrections operate on the same, already-mutated document). The `Runner` now sorts autocorrecting linters by priority, with a stable alphabetical fallback.
- `reset_autocorrect_state`: clears per-run bookkeeping, since linter instances are reused across files. Linters that accumulate extra state (merges, deletions) override it and call `super`.

**Runner (`lib/haml_lint/runner.rb`)**

- Autocorrecting linters are now ordered by `autocorrect_priority` before running.

**Linters with auto-correction**

Safe (run under both `-a` and `-A`): `ClassAttributeWithStaticValue`, `ClassesBeforeIds`, `EmptyObjectReference`, `FinalNewline`, `ImplicitDiv`, `LeadingCommentSpace`, `RubyComments`, `SpaceBeforeScript`, `SpaceInsideHashAttributes`, `TagName`, `TrailingEmptyLines`, `TrailingWhitespace`, `UnnecessaryInterpolation`.

Unsafe (run only under `-A`): `ConsecutiveComments`, `EmptyScript`, `MultilineScript`.

### Two correction patterns

- **Per-line (most common)**: `visit_*` methods buffer edits with `correct_line`; the base class flushes them automatically in `after_visit_root`. No extra boilerplate (e.g. `TagName` lowercasing `%BODY` into `%body`).
- **Whole-document**: global passes build a new source and call `apply_autocorrect` themselves inside `visit_root` (e.g. `TrailingWhitespace`). Linters with cross-line state such as `MultilineScript` override `after_visit_root` (calling `super`) to fold their accumulated merges.

### Testing

- Each corrected linter gets a `context 'with autocorrect'` covering the correction itself, the `corrected: true` flag, the no-op case (`source_was_changed == false`), inline `haml-lint:disable` handling, and `:all` mode where relevant.
- New base-class coverage in `spec/haml_lint/linter_spec.rb` and orchestration/ordering coverage in `spec/haml_lint/runner_spec.rb`.

```bash
bundle exec rspec
STUB_RUBOCOP=true bundle exec rspec   # faster; skips the real RuboCop round-trip
```

### Notes

- The `corrected:` flag passed to `record_lint` is optimistic: it's set when the correction is queued/applied, before the reparse. If `Document#change_source` rolls back on invalid HAML the lint still reports `[Corrected]`, so specs assert against `document.source` / `document.source_was_changed`, not just `lint.corrected`.
- `CHANGELOG.md` gains an Unreleased entry.
