### PR TITLE
Fix UnnecessaryStringOutput false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HAML-Lint Changelog
 
+### Unreleased
+
+* Fix `UnnecessaryStringOutput` false positives
+
 ### 0.73.0
 
 * Relax `parallel` dependency from `~> 1.10` to `>= 1.10`

--- a/lib/haml_lint/linter/unnecessary_string_output.rb
+++ b/lib/haml_lint/linter/unnecessary_string_output.rb
@@ -33,8 +33,11 @@ module HamlLint
 
     def outputs_string_literal?(script_node)
       return unless tree = parse_ruby(script_node.script)
-      %i[str dstr].include?(tree.type) &&
-        !starts_with_reserved_character?(tree.children.first)
+      return unless %i[str dstr].include?(tree.type)
+
+      !starts_with_reserved_character?(tree.children.first) &&
+        !contains_escape_sequence?(tree) &&
+        !contains_significant_whitespace?(tree)
     rescue ::Parser::SyntaxError
       # Gracefully ignore syntax errors, as that's managed by a different linter
     end
@@ -44,6 +47,35 @@ module HamlLint
     def starts_with_reserved_character?(stringish)
       string = stringish.respond_to?(:children) ? stringish.children.first : stringish
       string =~ %r{\A\s*[/#-=%~]} if string.is_a?(String)
+    end
+
+    # The ordered segments of a string literal, including any interpolation.
+    # A plain `str` node has no interpolation, so it is its own only segment.
+    def string_segments(tree)
+      tree.type == :dstr ? tree.children : [tree]
+    end
+
+    # Returns whether any literal portion of the string contains a backslash
+    # escape (e.g. `\n`, `\t`, `\u202F`). Such escapes are interpreted inside
+    # a Ruby string but would be emitted verbatim as HAML plain text, so the
+    # `= "..."` form is not equivalent to the unwrapped plain text.
+    def contains_escape_sequence?(tree)
+      string_segments(tree).any? do |segment|
+        segment.type == :str && segment.location.expression.source.include?('\\')
+      end
+    end
+
+    # Returns whether the string begins or ends with whitespace. HAML strips
+    # trailing whitespace from plain text (and leading whitespace denotes
+    # indentation), so unwrapping such a string would change the output.
+    def contains_significant_whitespace?(tree)
+      segments = string_segments(tree)
+      bounded_by_whitespace?(segments.first, /\A\s/) ||
+        bounded_by_whitespace?(segments.last, /\s\z/)
+    end
+
+    def bounded_by_whitespace?(segment, pattern)
+      segment.type == :str && segment.children.first.to_s.match?(pattern)
     end
   end
 end

--- a/spec/haml_lint/linter/unnecessary_string_output_spec.rb
+++ b/spec/haml_lint/linter/unnecessary_string_output_spec.rb
@@ -108,6 +108,36 @@ describe HamlLint::Linter::UnnecessaryStringOutput do
     it { should report_lint }
   end
 
+  context 'when script outputs a string containing a unicode escape sequence' do
+    let(:haml) { '= "#{price}\u202F\u0243"' }
+
+    it { should_not report_lint }
+  end
+
+  context 'when script outputs a string containing a tab escape sequence' do
+    let(:haml) { '= "first\tsecond"' }
+
+    it { should_not report_lint }
+  end
+
+  context 'when script outputs a string with a trailing space' do
+    let(:haml) { '= "#{label}: "' }
+
+    it { should_not report_lint }
+  end
+
+  context 'when script outputs a string with a leading space' do
+    let(:haml) { '= " #{value}"' }
+
+    it { should_not report_lint }
+  end
+
+  context 'when script outputs a string whose interior contains whitespace' do
+    let(:haml) { '= "#{first} and #{second}"' }
+
+    it { should report_lint }
+  end
+
   context 'when script is a comment' do
     let(:haml) { '=# comment' }
 


### PR DESCRIPTION
Fixes #500 

## Summary

Fixes two false positives in the `UnnecessaryStringOutput` linter, which flags `= "string"` and suggests rewriting it as plain text `string`. That rewrite is only safe when the two forms render identically, but a Ruby double-quoted string does two things HAML plain text does not:

1. **Backslash escapes** (`\u202F`, `\t`, `\n`, …) are interpreted inside a Ruby string, but emitted verbatim as HAML plain text. The reported case `= "#{user.payment_price_btc}\u202F\u0243"` would render the literal text `\u202F\u0243` after unwrapping.
2. **Leading/trailing whitespace** is preserved in a Ruby string, but HAML strips trailing whitespace from plain text (and leading whitespace denotes indentation). `= "#{t(:k)}: "` renders `"VALUE: "`, but the unwrapped form drops the trailing space → `"VALUE:"`.

The linter now skips the lint in both cases, keeping every suggested rewrite behavior-preserving. The guard is conservative, it errs toward not reporting rather than proposing a rewrite that changes output. Genuine cases such as `= "hello #{world}"` and `= "#{a} x #{b}"` are still flagged.

## Testing

- Added specs covering unicode/tab escape sequences and leading/trailing whitespace, plus an interior-whitespace case that must still be flagged.
- `bundle exec rspec spec/haml_lint/linter/unnecessary_string_output_spec.rb`, 25 examples, 0 failures.
- Full linter suite green; RuboCop clean on the changed files.