### PR TITLE
Clean up RuboCop config deprecation warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
 
 AllCops:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -85,7 +85,7 @@ Style/PercentLiteralDelimiters:
 
 # Renaming `has_something?` to `something?` obfuscates whether it is a "is-a" or
 # a "has-a" relationship.
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Enabled: false
 
 Style/SignalException:


### PR DESCRIPTION
Two small `.rubocop.yml` updates that remove deprecation warnings printed on every RuboCop run.

### 1. Use `plugins` instead of `require` for rubocop-performance

Loads `rubocop-performance` via the `plugins:` key instead of `require:`.

```diff
-require:
+plugins:
   - rubocop-performance
```

Since RuboCop 1.72, extensions that support the plugin API (such as `rubocop-performance`) are expected to be declared under `plugins:`. Keeping it under `require:` prints:

```
rubocop-performance extension supports plugin, specify `plugins: rubocop-performance`
instead of `require: rubocop-performance` in .rubocop.yml.
```

### 2. Rename `Naming/PredicateName` to `Naming/PredicatePrefix`

Updates the cop name to its current spelling.

```diff
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Enabled: false
```

The cop was renamed in RuboCop, so the old name triggers:

```
Warning: The `Naming/PredicateName` cop has been renamed to `Naming/PredicatePrefix`.
(obsolete configuration found in .rubocop.yml, please update it)
```

### Scope

Both changes only affect the **development environment**.
