### PR TITLE
Fix `Layout/EmptyLineAfterGuardClause` false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HAML-Lint Changelog
 
+### Unreleased
+
+* Fix `Layout/EmptyLineAfterGuardClause` false positive for a blank line at the end of a `:ruby` filter
+
 ### 0.73.0
 
 * Relax `parallel` dependency from `~> 1.10` to `>= 1.10`

--- a/lib/haml_lint/ruby_extraction/chunk_extractor.rb
+++ b/lib/haml_lint/ruby_extraction/chunk_extractor.rb
@@ -392,8 +392,10 @@ module HamlLint::RubyExtraction
       filter_name_indent = @original_haml_lines[node.line - 1].index(/\S/)
       if node.filter_type == 'ruby'
         # The indentation in node.text is normalized, so that at least one line
-        # is indented by 0.
-        lines = node.text.split("\n")
+        # is indented by 0. Split("\n", -1) + pop keeps trailing blank lines (plain split drops them),
+        # which the end marker needs so it doesn't land right after the last code line.
+        lines = node.text.split("\n", -1)
+        lines.pop
         lines.map! do |line|
           if !/\S/.match?(line)
             # whitespace or empty

--- a/spec/haml_lint/ruby_extraction/chunk_extractor_spec.rb
+++ b/spec/haml_lint/ruby_extraction/chunk_extractor_spec.rb
@@ -93,6 +93,25 @@ describe HamlLint::RubyExtraction::ChunkExtractor do
     end
   end
 
+  describe '#extract' do
+    let(:ruby_filter_chunk) do
+      chunks = described_class.new(document, script_output_prefix: 'HL.out = ').extract
+      chunks.find { |chunk| chunk.is_a?(HamlLint::RubyExtraction::RubyFilterChunk) }
+    end
+
+    context 'with a :ruby filter ending in a blank line' do
+      # A trailing blank line must be kept so that the chunk's end marker doesn't
+      # land right after the last line of code, which would make cops such as
+      # Layout/EmptyLineAfterGuardClause misfire. (String#split drops trailing
+      # empty strings unless given -1.)
+      let(:haml) { "- collection.each do |item|\n  :ruby\n    a = item.foo\n    next if a.nil?\n\n  %p= a\n" }
+
+      it 'preserves the trailing blank line in the extracted ruby' do
+        expect(ruby_filter_chunk.ruby_lines).to eq(['  a = item.foo', '  next if a.nil?', ''])
+      end
+    end
+  end
+
   describe '#extract_raw_tag_attributes_ruby_lines' do
     context 'with a tag attributes' do
       def do_test


### PR DESCRIPTION
`Linter::RuboCop` reconstructs a Ruby file from the fragments of a HAML template before handing it to RuboCop. When extracting the body of a `:ruby` filter, `ChunkExtractor#visit_filter` used `node.text.split("\n")`. `String#split` discards trailing empty strings unless given a limit of `-1`, so any blank line at the end of the filter was silently dropped from the extracted Ruby.

Because the blank line disappeared, the chunk's end marker landed immediately after the last line of code. For a filter ending in a guard clause this made RuboCop report `Layout/EmptyLineAfterGuardClause` against a blank line that actually exists in the HAML — a false positive.

This PR switches to `split("\n", -1)` and pops the empty entry produced by the trailing newline that `node.text` always ends with, yielding exactly `node.text.count("\n")` lines and preserving any trailing blank lines. This mirrors how the non-Ruby filter branch already handles line counting.

### Changes

- `lib/haml_lint/ruby_extraction/chunk_extractor.rb`: preserve trailing blank lines when extracting a `:ruby` filter body.
- `spec/haml_lint/ruby_extraction/chunk_extractor_spec.rb`: add a regression test asserting the extracted `RubyFilterChunk` keeps the trailing blank line.
- `CHANGELOG.md`: changelog entry.

### Testing

```bash
bundle exec rspec
bundle exec rubocop
```

Full suite passes, including the auto-correct round-trip specs run without `STUB_RUBOCOP`.

Before this change the new spec fails with:

```
expected: ["  a = item.foo", "  next if a.nil?", ""]
     got: ["  a = item.foo", "  next if a.nil?"]
```

Closes #653