### PR TITLE
Fix RuboCop lints reported on the wrong line on repeated runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HAML-Lint Changelog
 
+### Unreleased
+
+* Fix `RuboCop` lints being reported on the wrong line when the same file is
+  linted more than once, by no longer reusing RuboCop's result cache (#593)
+
 ### 0.73.0
 
 * Relax `parallel` dependency from `~> 1.10` to `>= 1.10`

--- a/lib/haml_lint/document.rb
+++ b/lib/haml_lint/document.rb
@@ -14,9 +14,6 @@ module HamlLint
     # @return [String] Haml template file path
     attr_reader :file
 
-    # @return [Boolean] true if source was read directly from `file` on-disk (rather than from stdin)
-    attr_reader :file_on_disk
-
     # @return [Boolean] true if source changes (from autocorrect) should be written to stdout instead of disk
     attr_reader :write_to_stdout
 
@@ -42,14 +39,12 @@ module HamlLint
     # @param source [String] Haml code to parse
     # @param options [Hash]
     # @option options :file [String] file name of document that was parsed
-    # @option options :file_on_disk [Boolean] true if source was read straight from `file` on disk
     # @option options :write_to_stdout [Boolean] true if source changes should be written to stdout
     # @raise [Haml::Parser::Error] if there was a problem parsing the document
     def initialize(source, options)
       @config = options[:config]
       @file = options.fetch(:file, STRING_SOURCE)
       @write_to_stdout = options[:write_to_stdout]
-      @file_on_disk = options[:file_on_disk] && @file != STRING_SOURCE
       @source_was_changed = false
       process_source(source)
     end

--- a/lib/haml_lint/linter/rubocop.rb
+++ b/lib/haml_lint/linter/rubocop.rb
@@ -20,10 +20,12 @@ module HamlLint
     class Runner < ::RuboCop::Runner
       attr_reader :offenses
 
-      def run(haml_path, ruby_code, config:, allow_cache: false)
-        @allow_cache = allow_cache
+      def run(haml_path, ruby_code, config:)
         @offenses = []
         @config_store.instance_variable_set(:@options_config, config)
+        # Using stdin also disables RuboCop's result cache, which is intentional:
+        # it reconstructs offense positions from the on-disk HAML, not the Ruby we
+        # inspected, so reusing it misreports lines (sds/haml-lint#593).
         @options[:stdin] = ruby_code
         super([haml_path])
       end
@@ -39,20 +41,6 @@ module HamlLint
       # @param offenses [Array<RuboCop::Cop::Offense>]
       def file_finished(_file, offenses)
         @offenses = offenses
-      end
-
-      # RuboCop caches results by taking a hash of the file contents & path, among other things.
-      # It disables its cache when working on file-content from stdin.
-      # Unfortunately we always use RuboCop's stdin, even when we're linting a file on-disk.
-      # So, override RuboCop::Runner#cached_run? so that it'll allow caching results, so long
-      # as haml-lint itself isn't being invoked with files on stdin.
-      def cached_run?
-        return false unless @allow_cache
-
-        @cached_run ||=
-          (@options[:cache] == 'true' ||
-          (@options[:cache] != 'false' && @config_store.for_pwd.for_all_cops['UseCache'])) &&
-          !@options[:auto_gen_config]
       end
     end
 
@@ -242,7 +230,7 @@ module HamlLint
     # @param path [String] the path to tell RuboCop we are running
     # @return [Array<RuboCop::Cop::Offense>, String]
     def run_rubocop(rubocop_runner, ruby_code, path) # rubocop:disable Metrics
-      rubocop_runner.run(path, ruby_code, config: rubocop_config_for(path), allow_cache: @document&.file_on_disk)
+      rubocop_runner.run(path, ruby_code, config: rubocop_config_for(path))
 
       if ENV['HAML_LINT_INTERNAL_DEBUG'] == 'true'
         if rubocop_runner.offenses.empty?

--- a/lib/haml_lint/runner.rb
+++ b/lib/haml_lint/runner.rb
@@ -89,7 +89,6 @@ module HamlLint
       begin
         document = HamlLint::Document.new source.contents, file: source.path,
                                                            config: config,
-                                                           file_on_disk: !source.stdin?,
                                                            write_to_stdout: @autocorrect_stdout
       rescue HamlLint::Exceptions::ParseError => e
         return [HamlLint::Lint.new(HamlLint::Linter::Syntax.new(config), source.path,

--- a/lib/haml_lint/source.rb
+++ b/lib/haml_lint/source.rb
@@ -20,10 +20,5 @@ module HamlLint
     def contents
       @contents ||= @io&.read || File.read(path)
     end
-
-    # @return [boolean] true if we're reading from stdin rather than a file path
-    def stdin?
-      !@io.nil?
-    end
   end
 end

--- a/spec/haml_lint/linter/rubocop_spec.rb
+++ b/spec/haml_lint/linter/rubocop_spec.rb
@@ -331,6 +331,55 @@ describe HamlLint::Linter::RuboCop do
     end
   end
 
+  context 'when linting the same on-disk file more than once (#593)' do
+    # sds/haml-lint#593: RuboCop's result cache reconstructs offense positions
+    # from the on-disk HAML, but we inspect the extracted Ruby via stdin, so a
+    # cache hit misreports lines. haml-lint must never use that cache.
+    include_context 'linter'
+
+    # We drive the runs manually so we can lint the file twice.
+    let(:run_method_to_use) { nil }
+
+    let(:haml) { <<~HAML }
+      %p
+        Hi \#{foo}
+        \#{ foo}
+    HAML
+
+    around do |example|
+      Dir.mktmpdir do |dir|
+        @haml_path = File.join(dir, 'foo.haml')
+        File.write(@haml_path, normalize_indent(haml))
+        # Isolated, empty cache dir: starts cold and spares the real one.
+        ::RuboCop::ResultCache.instance_variable_set(:@cache_root, nil)
+        HamlLint::Utils.with_environment('RUBOCOP_CACHE_ROOT' => File.join(dir, 'rubocop_cache')) do
+          example.run
+        end
+      ensure
+        ::RuboCop::ResultCache.instance_variable_set(:@cache_root, nil)
+      end
+    end
+
+    def lint_line_numbers
+      # Point the document at the real on-disk file so RuboCop would be able to
+      # cache results for it (the path is part of the cache key).
+      document = HamlLint::Document.new(normalize_indent(haml),
+                                        options.merge(file: @haml_path))
+      linter = described_class.new(config)
+      linter.run(document)
+      linter.lints.map(&:line)
+    end
+
+    it 'reports offenses on the same correct line on every run' do
+      # `#{ foo}` (with the extra space) is on line 3.
+      first_run = lint_line_numbers
+      second_run = lint_line_numbers
+
+      expect(first_run).to all(eq(3))
+      expect(second_run).to eq(first_run)
+    end
+  end
+
   describe '#run_rubocop' do
     subject { described_class.new(config).send(:run_rubocop, rubocop_runner, 'foo', 'some_file.rb') }
 


### PR DESCRIPTION
Closes #593

## Summary

Running `haml-lint` on the same file more than once could report RuboCop offenses on **different lines each run**. The first (cold-cache) run was correct; every subsequent (warm-cache) run shifted the reported line, and the wrong number stuck until the file was modified or renamed.

This PR fixes #593 by no longer reusing RuboCop's result cache, which is fundamentally incompatible with the way haml-lint feeds RuboCop.

## Reproduction

```haml
%p
  Hi #{foo}
  #{ foo}
```

```console
$ rm -rf ~/.cache/rubocop_cache
$ bundle exec haml-lint bug.haml        # cold cache
bug.haml:3 [W] RuboCop: Layout/SpaceAroundOperators: ...
bug.haml:3 [W] RuboCop: Layout/ExtraSpacing: ...

$ bundle exec haml-lint bug.haml        # warm cache
bug.haml:2 [W] RuboCop: Layout/SpaceAroundOperators: ...   # <-- wrong line
bug.haml:2 [W] RuboCop: Layout/ExtraSpacing: ...           # <-- wrong line
```

The extra space lives in `#{ foo}` on **line 3**, so line 3 is correct.

## Root cause

`Linter::RuboCop` does not run RuboCop on the HAML file. It reconstructs a valid Ruby file from the fragments scattered through the template and feeds that Ruby to RuboCop **via stdin**, while telling RuboCop the path is the **HAML file**.

RuboCop's parent `Runner#cached_run?` deliberately disables the result cache whenever stdin is used (`!@options[:stdin]`). PR #576 (`bcf34fd`) overrode that method to re-enable caching for on-disk files, purely for performance.

That override is unsafe because of how RuboCop's cache stores and restores offenses (`RuboCop::CachedData`):

- **On save**, an offense is serialized as **byte offsets only**
  (`begin_pos` / `end_pos`) — no line number.
- **On load (cache hit)**, the offense location is rebuilt with
  `Parser::Source::Range.new(source_buffer, begin_pos, end_pos)`, where
  `source_buffer` is `File.read(@filename)` — i.e. the **on-disk HAML**, not the
  generated Ruby that produced those offsets.

So the byte offsets, computed against the (longer) generated Ruby, are
reinterpreted against the (shorter) HAML file. The resulting line numbers are
garbage.

### Proven end-to-end

Instrumenting the pipeline on the reproduction file:

```
Generated Ruby, line 9: "  HL.out =  foo"   begin_pos=165   (from `#{ foo}`, HAML line 3)

COLD: offense.line = 9  (buffer = generated Ruby)   -> source_map[9] = 3  -> HAML line 3  ✓
WARM: offense.line = 4  (buffer = HAML, 25 bytes;
                         begin_pos=165 is past EOF,
                         Parser extrapolates to "line 4") -> source_map[4] = 2  -> HAML line 2  ✗
```

The cached offense's byte offset (165) lands far beyond the 25-byte HAML file; Parser extrapolates to a meaningless line, and the source-map translation then yields line 2. The number is stable-but-wrong because RuboCop's cache key (`file_checksum`) hashes the on-disk HAML content — so it only changes when the file is edited or renamed, exactly as reported in the issue.

## The fix

Remove the `cached_run?` override and the supporting plumbing (`allow_cache` / `file_on_disk` / `stdin?`). This is a precise revert of PR #576's caching mechanism. Because haml-lint always sets `@options[:stdin]`, RuboCop's own `cached_run?` now correctly returns `false`, so the corrupting cache path is never taken.

Files changed:

- `lib/haml_lint/linter/rubocop.rb` — drop the `cached_run?` override and the `allow_cache` parameter; add a short comment explaining why caching must stay off.
- `lib/haml_lint/document.rb` — remove `file_on_disk`.
- `lib/haml_lint/runner.rb` — stop passing `file_on_disk:`.
- `lib/haml_lint/source.rb` — remove the now-unused `stdin?`.

## Tests

Added a regression spec to `spec/haml_lint/linter/rubocop_spec.rb` that lints the #593 file **twice** on disk with an isolated RuboCop cache root and asserts the reported line is correct and stable.

## Performance impact

Benchmarked on a 300-file HAML corpus with embedded Ruby (wall clock):

| Scenario              | `main` (cached) | This PR (no cache) |
| --------------------- | --------------: | -----------------: |
| Run 1 — cold cache    |           1.31s |              1.25s |
| Run 2 — warm cache    |           1.01s |              1.25s |
| Run 3 — warm cache    |           1.02s |              1.23s |
| On-disk cache written |          1.2 MB |               none |

- **No impact** on the first/cold run, on changed files (the cache key includes file content, so edited files were never served from cache), in CI, or with `--parallel` and haml-lint's own in-memory cache.
- The only cost is **re-linting unchanged files** with a warm cache (~20% / ~0.2s over 300 files here; PR #576 measured up to ~2x on their app). That speed-up, however, came from reusing offenses whose line numbers were corrupted — it was buying incorrect output.

A correct, future enhancement would be a haml-lint-level cache keyed on the HAML content and storing lints already mapped to HAML lines, which would restore the speed-up without reintroducing this bug. That is out of scope for this fix.
