### PR TITLE
Add `UnescapedHtml` linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HAML-Lint Changelog
 
+### Unreleased
+
+* Add `UnescapedHtml` linter to flag use of `!=`/`!~`/`!` unescaped HTML output
+
 ### 0.73.0
 
 * Relax `parallel` dependency from `~> 1.10` to `>= 1.10`

--- a/config/default.yml
+++ b/config/default.yml
@@ -118,6 +118,9 @@ linters:
   TrailingWhitespace:
     enabled: true
 
+  UnescapedHtml:
+    enabled: true
+
   UnnecessaryInterpolation:
     enabled: true
 

--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -31,6 +31,7 @@ Below is a list of linters supported by `haml-lint`, ordered alphabetically.
 * [TagName](#tagname)
 * [TrailingEmptyLines](#trailingemptylines)
 * [TrailingWhitespace](#trailingwhitespace)
+* [UnescapedHtml](#unescapedhtml)
 * [UnnecessaryInterpolation](#unnecessaryinterpolation)
 * [UnnecessaryStringOutput](#unnecessarystringoutput)
 * [ViewLength](#viewlength)
@@ -765,6 +766,25 @@ HAML documents should not contain empty lines at the end of the file.
 
 HAML documents should not contain trailing whitespace (spaces or tabs) on any
 lines.
+
+## UnescapedHtml
+
+Flags use of HAML's unescaped-output markers (`!=`, `!~`, and the unescaped
+plain-text `!`), which bypass HTML escaping. Like `raw`, `html_safe`, and `h()`
+in Rails, these make it easy to accidentally introduce XSS vulnerabilities when
+the output includes user-controlled data.
+
+**Bad: output is not HTML-escaped**
+```haml
+!= "Username: <strong>#{user.name}</strong>"
+%p!= user_supplied_html
+```
+
+**Good: output is HTML-escaped**
+```haml
+= "Username: #{user.name}"
+%p= user_supplied_html
+```
 
 ## UnnecessaryInterpolation
 

--- a/lib/haml_lint/linter/unescaped_html.rb
+++ b/lib/haml_lint/linter/unescaped_html.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module HamlLint
+  # Flags HAML's unescaped-output markers (`!=`, `!~`, and the unescaped
+  # plain-text `!`), which bypass HTML escaping.
+  #
+  # Like `raw`, `html_safe`, and `h()` in Rails, these make it easy to
+  # accidentally introduce XSS vulnerabilities when the output includes
+  # user-controlled data, e.g.:
+  #
+  #   != "Username: <strong>#{user.name}</strong>"
+  class Linter::UnescapedHtml < Linter
+    include LinterRegistry
+
+    MESSAGE =
+      'Avoid outputting unescaped HTML with `!`; it bypasses HTML escaping and ' \
+      'can introduce XSS vulnerabilities. Sanitize the value instead.'
+
+    def visit_script(node)
+      record_lint(node, MESSAGE) if /\A\s*!/.match?(node.source_code)
+    end
+
+    def visit_tag(node)
+      record_lint(node, MESSAGE) if node.unescape_html?
+    end
+  end
+end

--- a/lib/haml_lint/tree/tag_node.rb
+++ b/lib/haml_lint/tree/tag_node.rb
@@ -33,6 +33,16 @@ module HamlLint::Tree
       @value[:parse] && !@value[:value].strip.empty?
     end
 
+    # Whether this tag outputs unescaped HTML via a `!` marker, e.g. `%tag!=` or
+    # `%tag!~`.
+    #
+    # @return [true,false]
+    def unescape_html?
+      return false unless contains_script?
+
+      /\A\s*[<>]*\s*!/.match?(inline_marker_source)
+    end
+
     # Returns whether this tag has a specified attribute.
     #
     # @return [true,false]
@@ -94,30 +104,18 @@ module HamlLint::Tree
     #
     # @return [Hash]
     def attributes_source
-      @attributes_source ||=
-        begin
-          _explicit_tag, static_attrs, rest =
-            source_code.scan(/\A\s*(%[-:\w]+)?([-:\w.\#]*)(.*)/m)[0]
+      parsed_attributes_source[:attributes]
+    end
 
-          attr_types = {
-            '{' => [:hash, %w[{ }]],
-            '(' => [:html, %w[( )]],
-            '[' => [:object_ref, %w[[ ]]],
-          }
-
-          attr_source = { static: static_attrs }
-          while rest
-            type, chars = attr_types[rest[0]]
-            break unless type # Not an attribute opening character, so we're done
-
-            # Can't define multiple of the same attribute type (e.g. two {...})
-            break if attr_source[type]
-
-            attr_source[type], rest = Haml::Util.balance(rest, *chars)
-          end
-
-          attr_source
-        end
+    # Source that follows the tag name and attributes. It begins with the
+    # content marker (e.g. `=`, `!=`, `~`, `!~`, or plain text).
+    #
+    # @example For `%tag.class!= foo`, this returns:
+    #   '!= foo'
+    #
+    # @return [String]
+    def inline_marker_source
+      parsed_attributes_source[:marker]
     end
 
     # Whether this tag node has a set of hash attributes defined via the
@@ -228,6 +226,40 @@ module HamlLint::Tree
     end
 
     private
+
+    # Parses the source code following the tag name once into its attribute
+    # sources and the remaining inline content marker.
+    #
+    # @return [Hash{Symbol => Object}] `:attributes` source hash (keyed by
+    #   `:static`/`:hash`/`:html`/`:object_ref`) and the `:marker` string
+    def parsed_attributes_source
+      @parsed_attributes_source ||=
+        begin
+          _explicit_tag, static_attrs, rest =
+            source_code.scan(/\A\s*(%[-:\w]+)?([-:\w.\#]*)(.*)/m)[0]
+
+          attr_types = {
+            '{' => [:hash, %w[{ }]],
+            '(' => [:html, %w[( )]],
+            '[' => [:object_ref, %w[[ ]]],
+          }
+
+          attr_source = { static: static_attrs }
+          while rest
+            type, chars = attr_types[rest[0]]
+            break unless type # Not an attribute opening character, so we're done
+
+            # Can't define multiple of the same attribute type (e.g. two {...})
+            break if attr_source[type]
+
+            attr_source[type], rest = Haml::Util.balance(rest, *chars)
+          end
+
+          # Whatever remains after the tag name and attributes begins with the
+          # content marker (e.g. `=`, `!=`, `~`, `!~`, or plain text).
+          { attributes: attr_source, marker: rest.to_s }
+        end
+    end
 
     def existing_attributes
       parsed_attrs = parsed_attributes

--- a/spec/haml_lint/linter/unescaped_html_spec.rb
+++ b/spec/haml_lint/linter/unescaped_html_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+describe HamlLint::Linter::UnescapedHtml do
+  include_context 'linter'
+
+  context 'when a script uses the escaped `=` marker' do
+    let(:haml) { '= user_input' }
+    it { should_not report_lint }
+  end
+
+  context 'when a script uses the unescaped `!=` marker' do
+    let(:haml) { '!= user_input' }
+    it { should report_lint line: 1 }
+  end
+
+  context 'when a script uses the unescaped preserve `!~` marker' do
+    let(:haml) { '!~ user_input' }
+    it { should report_lint line: 1 }
+  end
+
+  context 'when a script uses the escaped preserve `~` marker' do
+    let(:haml) { '~ user_input' }
+    it { should_not report_lint }
+  end
+
+  context 'when plain text is output unescaped with interpolation' do
+    let(:haml) { '! Hello #{user.name}' }
+    it { should report_lint line: 1 }
+  end
+
+  context 'when plain text is static (no unescape marker is meaningful)' do
+    let(:haml) { 'Just some static text' }
+    it { should_not report_lint }
+  end
+
+  context 'when a tag uses `!` on static text with no interpolation' do
+    let(:haml) { '%p! Just static text' }
+    it { should_not report_lint }
+  end
+
+  context 'when a tag uses the escaped `=` marker' do
+    let(:haml) { '%p= user_input' }
+    it { should_not report_lint }
+  end
+
+  context 'when a tag uses the unescaped `!=` marker' do
+    let(:haml) { '%p!= user_input' }
+    it { should report_lint line: 1 }
+  end
+
+  context 'when a tag uses the unescaped preserve `!~` marker' do
+    let(:haml) { '%p!~ user_input' }
+    it { should report_lint line: 1 }
+  end
+
+  context 'when a tag with classes and ids uses `!=`' do
+    let(:haml) { '%p.card#main!= user_input' }
+    it { should report_lint line: 1 }
+  end
+
+  context 'when a tag with hash attributes uses `!=`' do
+    let(:haml) { '%p{ title: "t" }!= user_input' }
+    it { should report_lint line: 1 }
+  end
+
+  context 'when a tag combines whitespace removal with `!=`' do
+    let(:haml) { '%p<>!= user_input' }
+    it { should report_lint line: 1 }
+  end
+
+  context 'when a tag uses whitespace removal with the escaped `=` marker' do
+    let(:haml) { '%p<>= user_input' }
+    it { should_not report_lint }
+  end
+
+  context 'when a tag has no inline script' do
+    let(:haml) { '%p' }
+    it { should_not report_lint }
+  end
+
+  context 'when escaped output contains the Ruby `!=` operator' do
+    let(:haml) { '= a != b' }
+    it { should_not report_lint }
+  end
+
+  context 'when an escaped tag contains the Ruby `!=` operator' do
+    let(:haml) { '%p= a != b' }
+    it { should_not report_lint }
+  end
+
+  context 'when a silent script contains the Ruby `!=` operator' do
+    let(:haml) { '- foo if a != b' }
+    it { should_not report_lint }
+  end
+
+  context 'when multiple unescaped markers are used' do
+    let(:haml) do
+      [
+        '!= first',
+        '%p!= second',
+        '! third #{value}',
+      ].join("\n")
+    end
+
+    it { should report_lint count: 3 }
+    it { should report_lint line: 1 }
+    it { should report_lint line: 2 }
+    it { should report_lint line: 3 }
+  end
+end


### PR DESCRIPTION
Closes #550

## Summary

Adds a new `UnescapedHtml` linter that flags HAML's unescaped-output markers, which bypass HTML escaping. As noted in #550, just like `raw`, `html_safe`, and `h()` in Rails, these markers make it easy to accidentally introduce XSS holes when the output includes user-controlled data — for example:

```haml
!= "Username: <strong>#{user.name}</strong>"
```

RuboCop's `Rails/OutputSafety` cop catches `raw`/`html_safe`/`safe_concat`, but it never sees these because they are a HAML construct, not Ruby. This linter fills that gap.

## What is flagged

The linter targets every HAML marker that emits **unescaped** output of **dynamic** content:

| HAML              | Flagged? | Reason                                         |
| ----------------- | :------: | ---------------------------------------------- |
| `= value`         |    no    | escaped output                                 |
| `~ value`         |    no    | escaped, whitespace-preserved output           |
| `!= value`        | **yes**  | unescaped output                               |
| `!~ value`        | **yes**  | unescaped, whitespace-preserved output         |
| `! text #{value}` | **yes**  | unescaped dynamic plain text                   |
| `%tag!= value`    | **yes**  | unescaped tag content                          |
| `%tag!~ value`    | **yes**  | unescaped, preserved tag content               |
| `! static text`   |    no    | static plain text — no injection vector        |
| `%p= a != b`      |    no    | the Ruby `!=` operator, not an unescape marker |

The distinction is intentional: only unescaped output of _dynamic_ content is reported, since static markup carries no injection risk.

## Implementation notes

- Detection is based on the node's source marker, not `@value[:escape_html]`:
  haml-lint parses with HTML escaping disabled, so both `=` and `!=` report
  `escape_html: false` and cannot be told apart that way.
- For `:script` nodes the check is anchored at the start of the source
  (`/\A\s*!/`), so it covers `!=`, `!~`, and the dynamic plain-text `!` form
  while never matching a Ruby `!=` operator inside an escaped expression.
- For `:tag` nodes a new `TagNode#unescape_html?` helper inspects the content
  marker that follows the tag name and attributes. The existing attribute-source
  scan was refactored into a single memoized `parsed_attributes_source` that now
  also exposes the trailing `inline_marker_source`, keeping tag-source parsing in
  one place.
- No autocorrect: rewriting `!=` to `=` would change behavior and could escape
  HTML the author intentionally left raw, so this is detection only.

## Enabled by default

The linter ships enabled in `config/default.yml`.

## Testing

```bash
bundle exec rspec spec/haml_lint/linter/unescaped_html_spec.rb spec/haml_lint/tree
bundle exec rubocop
```
