### PR TITLE
Keep file/line in the github reporter's log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # HAML-Lint Changelog
 
+### Unreleased
+
+* Keep the file, line, and linter name in the `github` reporter's log output, and add a
+  `title` to its annotations, so location information is no longer lost in the GitHub Actions
+  log
+
 ### 0.73.0
 
 * Relax `parallel` dependency from `~> 1.10` to `>= 1.10`

--- a/lib/haml_lint/reporter/github_reporter.rb
+++ b/lib/haml_lint/reporter/github_reporter.rb
@@ -3,16 +3,16 @@
 module HamlLint
   # Outputs GitHub workflow commands for GitHub check annotations when run within GitHub actions.
   class Reporter::GithubReporter < Reporter
+    # Characters to escape within a command message.
     ESCAPE_MAP = { '%' => '%25', "\n" => '%0A', "\r" => '%0D' }.freeze
+    # Property values also escape the `:` and `,` that delimit the command.
+    PROPERTY_ESCAPE_MAP = ESCAPE_MAP.merge(':' => '%3A', ',' => '%2C').freeze
 
     include Reporter::Utils
 
     def added_lint(lint, report)
-      if lint.severity >= report.fail_level
-        print_workflow_command(lint: lint)
-      else
-        print_workflow_command(severity: 'warning', lint: lint)
-      end
+      severity = lint.severity >= report.fail_level ? 'error' : 'warning'
+      print_workflow_command(lint, severity)
     end
 
     def display_report(report)
@@ -21,12 +21,30 @@ module HamlLint
 
     private
 
-    def print_workflow_command(lint:, severity: 'error')
-      log.log "::#{severity} file=#{lint.filename},line=#{lint.line}::#{github_escape(lint.message)}"
+    def print_workflow_command(lint, severity)
+      log.log "::#{severity} file=#{github_escape_property(lint.filename)}," \
+              "line=#{lint.line},title=#{github_escape_property(annotation_title(lint))}" \
+              "::#{github_escape(annotation_message(lint))}"
+    end
+
+    # Annotation title, naming the linter that produced the lint when known.
+    def annotation_title(lint)
+      lint.linter ? "haml-lint #{lint.linter.name}" : 'haml-lint'
+    end
+
+    # Message body, prefixed with the location and linter so it stays useful in the plain log.
+    def annotation_message(lint)
+      location = "#{lint.filename}:#{lint.line}"
+      location += " #{lint.linter.name}:" if lint.linter
+      "#{location} #{lint.message}"
     end
 
     def github_escape(string)
-      string.gsub(Regexp.union(ESCAPE_MAP.keys), ESCAPE_MAP)
+      string.to_s.gsub(Regexp.union(ESCAPE_MAP.keys), ESCAPE_MAP)
+    end
+
+    def github_escape_property(string)
+      string.to_s.gsub(Regexp.union(PROPERTY_ESCAPE_MAP.keys), PROPERTY_ESCAPE_MAP)
     end
   end
 end

--- a/spec/haml_lint/reporter/github_reporter_spec.rb
+++ b/spec/haml_lint/reporter/github_reporter_spec.rb
@@ -43,17 +43,30 @@ describe HamlLint::Reporter::GithubReporter do
         output[-1].should == "\n"
       end
 
-      it 'prints the filename for each lint' do
+      it 'sets the workflow command file property for each lint' do
         subject
         filenames.each do |filename|
-          output.scan(/#{filename}/).count.should == 1
+          output.scan(/file=#{filename}/).count.should == 1
         end
       end
 
-      it 'prints the line number for each lint' do
+      it 'sets the workflow command line property for each lint' do
         subject
         lines.each do |line|
-          output.scan(/#{line}/).count.should == 1
+          output.scan(/line=#{line}/).count.should == 1
+        end
+      end
+
+      it 'sets the annotation title to the linter name for each lint' do
+        subject
+        output.scan(/title=haml-lint SomeLinter/).count.should == 2
+      end
+
+      it 'keeps the location and linter name in the message so the log stays readable' do
+        subject
+        filenames.each_with_index do |filename, index|
+          location = "#{filename}:#{lines[index]} SomeLinter: #{descriptions[index]}"
+          output.scan(/#{Regexp.escape(location)}/).count.should == 1
         end
       end
 
@@ -84,8 +97,31 @@ describe HamlLint::Reporter::GithubReporter do
         end
       end
 
+      context 'when a message contains characters that delimit workflow commands' do
+        let(:descriptions) { ["Use 100%% width\nand height", 'Description of lint 2'] }
+
+        it 'escapes them so the command stays on a single line' do
+          subject
+          output.count("\n").should == 2
+          output.should include('Use 100%25%25 width%0Aand height')
+        end
+      end
+
       context 'when lint has no associated linter' do
         let(:linter) { nil }
+
+        it 'falls back to a generic annotation title' do
+          subject
+          output.scan(/title=haml-lint::/).count.should == 2
+        end
+
+        it 'keeps the location in the message without a linter name' do
+          subject
+          filenames.each_with_index do |filename, index|
+            location = "#{filename}:#{lines[index]} #{descriptions[index]}"
+            output.scan(/#{Regexp.escape(location)}/).count.should == 1
+          end
+        end
 
         it 'prints the description for each lint' do
           subject


### PR DESCRIPTION
Closes #495

## Problem

The `github` reporter emits GitHub Actions workflow commands like:

```
::error file=app/views/x.haml,line=12::Message
```

GitHub moves the `file`/`line` of a workflow command into the annotation shown in the "Files changed" tab, so they disappear from the plain Actions **log** — leaving only the bare message with no location. This makes the log much less useful than the default reporter, which is the trade-off reported in #495.

## Change

Enhance `Reporter::GithubReporter` so the location is preserved in both places:

- **Location stays in the log** — the command's message is now prefixed with
  `filename:line LinterName:`, so the log line reads e.g.
  `app/views/x.haml:12 RuboCop: Style/StringLiterals: ...` even after GitHub strips the
  `file`/`line` into the annotation.
- **Annotations get a `title`** — `title=haml-lint <LinterName>` (falling back to `haml-lint`
  when a lint has no linter), so annotations are labeled and distinguishable from other tools'.
- **Correct escaping** — message values escape `%`, `\n`, `\r`; property values (`file`,
  `title`, ...) additionally escape the `:` and `,` that delimit the command.

### Before

```
::error file=app/views/x.haml,line=12::Avoid defining `class` in attributes hash...
```

### After

```
::error file=app/views/x.haml,line=12,title=haml-lint ClassAttributeWithStaticValue::app/views/x.haml:12 ClassAttributeWithStaticValue: Avoid defining `class` in attributes hash...
```

The annotation in the Files tab still works exactly as before; the difference is that the log
now keeps the file, line, and linter name.

## Tests

- Updated the file/line assertions to target the `file=`/`line=` command properties.
- Added coverage for the annotation `title`, the location/linter prefix in the message (with and
  without an associated linter), and escaping of delimiter characters.
- `bundle exec rspec spec/haml_lint/reporter/github_reporter_spec.rb` — 18 examples, 0 failures.
- `bundle exec rubocop lib/haml_lint/reporter/github_reporter.rb` — no offenses.
