### PR TITLE
Fix `LineLength` not being disabled inside filter blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HAML-Lint Changelog
 
+### Unreleased
+
+* Fix `LineLength` not being disabled by `haml-lint:disable` comments inside filter blocks such as `:javascript` and `:css`
+
 ### 0.73.0
 
 * Relax `parallel` dependency from `~> 1.10` to `>= 1.10`

--- a/lib/haml_lint/tree/filter_node.rb
+++ b/lib/haml_lint/tree/filter_node.rb
@@ -17,5 +17,18 @@ module HamlLint::Tree
 
       "#{"\n" * nb_blank_lines}#{super}"
     end
+
+    # The line numbers that are contained within the node.
+    #
+    # Unlike most nodes, a filter's content begins on the line *after* the
+    # `:filtername` declaration, so the span runs from the declaration line
+    # through all of the indented content lines.
+    #
+    # @return [Range]
+    def line_numbers
+      return super if lines.empty?
+
+      (line..(line + lines.count))
+    end
   end
 end

--- a/spec/haml_lint/linter/line_length_spec.rb
+++ b/spec/haml_lint/linter/line_length_spec.rb
@@ -48,6 +48,44 @@ describe HamlLint::Linter::LineLength do
     it { should report_lint line: 6 }
   end
 
+  context 'when a long line within a filter block is disabled' do
+    let(:haml) do
+      [
+        '-# haml-lint:disable LineLength',
+        ':javascript',
+        '  let thisIsAVeryLongLineThatGoesWellBeyondTheConfiguredMaximumLineLengthLimitForThisLinter = true;',
+      ].join("\n")
+    end
+
+    it { should_not report_lint }
+
+    context 'across multiple content lines' do
+      let(:haml) do
+        [
+          '-# haml-lint:disable LineLength',
+          ':javascript',
+          '  let a = 1;',
+          '  let thisIsAVeryLongLineThatGoesWellBeyondTheConfiguredMaximumLineLengthLimitForThisLinter = true;',
+          '  let b = 2;',
+        ].join("\n")
+      end
+
+      it { should_not report_lint }
+    end
+
+    context 'within a :css filter' do
+      let(:haml) do
+        [
+          '-# haml-lint:disable LineLength',
+          ':css',
+          '  .hero { background-image: url(https://example.com/assets/images/hero-background.png); }',
+        ].join("\n")
+      end
+
+      it { should_not report_lint }
+    end
+  end
+
   context 'when there is a directive on the line before a multiline pipe' do
     let(:haml) do
       <<-HAML

--- a/spec/haml_lint/tree/node_spec.rb
+++ b/spec/haml_lint/tree/node_spec.rb
@@ -236,6 +236,30 @@ describe HamlLint::Tree::Node do
 
       it { should == (1..1) }
     end
+
+    context 'for a filter node whose content spans subsequent lines' do
+      let(:haml) do
+        <<-HAML
+          :javascript
+            let a = 1;
+            let b = 2;
+        HAML
+      end
+
+      it { should == (1..3) }
+
+      context 'with a blank line after the declaration' do
+        let(:haml) do
+          <<-HAML
+            :javascript
+
+              let a = 1;
+          HAML
+        end
+
+        it { should == (1..3) }
+      end
+    end
   end
 
   describe '#predecessor' do


### PR DESCRIPTION
Fixes #623

## Problem

A `haml-lint:disable LineLength` comment had no effect on long lines that live
inside a filter block such as `:javascript` or `:css`:

```haml
-# haml-lint:disable LineLength
:javascript
  let thisIsLongButDescriptiveVariableNameWhoseSolePurposeIsToDemonstrateTheIssueBeingReportedAlthoughNoOneShouldNameVariablesLikeThatInPractice = true;
```

```
example.haml:3 [W] LineLength: Line is too long. [152/80]
```

## Root cause

`Linter::LineLength` resolves the node that owns each over-long line via `RootNode#node_for_line`, then checks whether the linter was disabled for that node through the `haml-lint:disable` directive chain.

A `FilterNode` sits on the `:filtername` _declaration_ line, but its content (`text`) lives on the _following_ lines. The base `Node#line_numbers` assumes a node's text starts on its own line, so for a one-line filter at line 2 it computed `line + lines.count - 1 = 2` — never covering line 3.

With no node covering line 3, `node_for_line` fell through to its best-guess branch, which only accepts `script`/`silent_script`/`tag` node types (not `filter`), and so returned a `NullNode`. A `NullNode` carries no directives, so the disable comment was silently lost and the lint fired.

## Fix

Override `line_numbers` in `FilterNode` to account for content beginning one line _after_ the declaration, so the node's span covers all of its indented content lines. The existing blank-line compensation in `FilterNode#text` keeps `lines.count` accurate, so filters with a blank line after the declaration work too.

## Verification

- The reproduction case now reports **0 lints**.
- A long line is still reported when the linter is **not** disabled, including a
  long line in a sibling node _after_ the filter (no over-reach).
- Covered `:javascript` (single and multiple content lines), `:css`, and the
  blank-line-after-declaration edge case.
- Added specs to `line_length_spec.rb` and `node_spec.rb`.
- Full suite: **1065 examples, 0 failures**; RuboCop clean.