### PR TITLE
Fix false `Lint/UselessAssignment` for HTML-style (parens) attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HAML-Lint Changelog
 
+### Unreleased
+
+* Fix RuboCop reporting a false `Lint/UselessAssignment`
+
 ### 0.73.0
 
 * Relax `parallel` dependency from `~> 1.10` to `>= 1.10`

--- a/lib/haml_lint/ruby_extraction/chunk_extractor.rb
+++ b/lib/haml_lint/ruby_extraction/chunk_extractor.rb
@@ -300,7 +300,13 @@ module HamlLint::RubyExtraction
       end
 
       if attributes_code&.start_with?('{')
-        # Looks like the .foo(bar = 123) case. Ignoring.
+        # HTML-style (parens) attributes, e.g. %div(foo=foo), arrive as a synthesized hash string
+        # like '{"foo" => foo,}'. That text isn't present verbatim in the HAML, so we can't map
+        # RuboCop corrections back and intentionally don't autocorrect it. We still extract the
+        # attribute *values* as a non-correctable chunk so RuboCop sees variables used here;
+        # otherwise they look unused (false Lint/UselessAssignment, plus unsafe autocorrect that
+        # removes the assignment). See issue #648.
+        add_html_attributes_value_usage(node, attributes_code, indent: indent)
         attributes_code = nil
       end
 
@@ -343,6 +349,22 @@ module HamlLint::RubyExtraction
                                              indent_to_remove: extra_indent)
 
       final_line_index
+    end
+
+    # For HTML-style (parens) attributes, adds the attribute value expressions as a
+    # non-autocorrectable chunk purely so RuboCop counts the variables/methods used there.
+    def add_html_attributes_value_usage(node, attributes_code, indent:)
+      ast = parse_ruby(attributes_code)
+      return unless ast&.type == :hash
+
+      value_sources = ast.children.filter_map do |pair|
+        next unless pair.type == :pair
+        pair.children[1]&.source
+      end
+      return if value_sources.empty?
+
+      lines = value_sources.map { |value| "#{' ' * indent}#{script_output_prefix}#{value}" }
+      @ruby_chunks << AdHocChunk.new(node, lines)
     end
 
     # Visiting the script besides tag. The part to the right of the equal sign of

--- a/spec/haml_lint/linter/rubocop_autocorrect_examples/tag_attributes_examples.txt
+++ b/spec/haml_lint/linter/rubocop_autocorrect_examples/tag_attributes_examples.txt
@@ -248,14 +248,58 @@ end
   %tag{bar: 123, hello: 42}
 
 
-!!! ignores old style attribute hash
+!!! extracts values of old style (parens) attributes so they count as used
 %tag(bar  =  123)
 ---
 haml_lint_tag_1
+HL.out = 123
 ---
 haml_lint_tag_1
+HL.out = 123
 ---
 %tag(bar  =  123)
+
+
+!!! parens attributes mark a variable as used, no false UselessAssignment
+- foo = 'foo'
+%div(foo=foo)
+---
+haml_lint_marker_1
+foo = 'foo'
+haml_lint_marker_3
+haml_lint_tag_4 $$2
+HL.out = foo
+---
+haml_lint_marker_1
+foo = 'foo'
+haml_lint_marker_3
+haml_lint_tag_4
+HL.out = foo
+---
+- foo = 'foo'
+%div(foo=foo)
+
+
+!!! parens attributes mark variables as used for every value (#648)
+- foo = 'foo'
+%div(foo=foo bar=foo)
+---
+haml_lint_marker_1
+foo = 'foo'
+haml_lint_marker_3
+haml_lint_tag_4 $$2
+HL.out = foo
+HL.out = foo
+---
+haml_lint_marker_1
+foo = 'foo'
+haml_lint_marker_3
+haml_lint_tag_4
+HL.out = foo
+HL.out = foo
+---
+- foo = 'foo'
+%div(foo=foo bar=foo)
 
 
 !!! fixes attribute methods

--- a/spec/haml_lint/linter/rubocop_spec.rb
+++ b/spec/haml_lint/linter/rubocop_spec.rb
@@ -234,6 +234,17 @@ describe HamlLint::Linter::RuboCop do
       it { should report_lint line: 2, corrected: false }
     end
 
+    context 'for a variable used only in HTML-style (parens) attributes' do
+      let(:haml) do
+        [
+          "- foo = 'foo'",
+          '%div(foo=foo)',
+        ].join("\n")
+      end
+
+      it { should_not report_lint }
+    end
+
     context 'indentation detection edge cases' do
       let(:run_method_to_use) { nil }
 


### PR DESCRIPTION
Fixes #648

## Problem

For HTML-style (parentheses) attributes, RuboCop reports a false `Lint/UselessAssignment` and, worse, **auto-correct removes the assignment**, breaking the rendered output:

```haml
- foo = 'foo'
%div(foo=foo)     # [W] Lint/UselessAssignment: Useless assignment to variable - `foo`
```

Running `--auto-correct` deletes the `- foo = 'foo'` line entirely (the `foo` on the right of `=` is still evaluated as Ruby, so the template breaks). The equivalent Ruby-style (curly) syntax works correctly:

```haml
- foo = 'foo'
%div{ foo: foo }  # no lint
```

## Root cause

HAML hands parens attributes to the Ruby extractor as a _synthesized_ hash string (e.g. `%div(foo=foo)` → `'{"foo" => foo,}'`). That text isn't present verbatim in the HAML source, so corrections can't be mapped back, and `ChunkExtractor#visit_tag_attributes` was **discarding the whole attribute**:

```ruby
if attributes_code&.start_with?('{')
  # Looks like the .foo(bar = 123) case. Ignoring.
  attributes_code = nil
end
```

Because the attribute was dropped, the `foo` reference never reached RuboCop, so the assignment looked unused — hence the false positive and the unsafe removal.

(Feeding the synthesized hash to RuboCop directly is not an option: it generates spurious offenses on code the user never wrote — `Style/TrailingCommaInHashLiteral`, `Layout/SpaceInsideHashLiteralBraces`, `Style/StringLiterals`.)

## Fix

Extract only the attribute **value expressions** from the synthesized hash and emit them as a non-correctable chunk (`HL.out = <value>`), so RuboCop sees the variables being used. Variable usage is now counted, eliminating both the false positive and the destructive auto-correct.

Auto-correct of the Ruby _inside_ parens attributes remains intentionally unsupported (mapping `{"foo" => foo,}` back to `(foo=foo)` is not feasible) — this change only makes the usage visible. As a beneficial side effect, the values are now linted (without auto-correct), consistent with how curly attributes already behave.

## Tests

- New regression spec in `rubocop_spec.rb` verified it fails on the old
  code and passes with the fix.
- Updated/added examples in `rubocop_autocorrect_examples/tag_attributes_examples.txt`
  (single value, multiple values), which exercise the full RuboCop round-trip and prove
  the assignment is preserved.

## Verification

- Manual: `%div(foo=foo)` with `- foo = 'foo'` → 0 RuboCop lints;
- `--auto-correct` leaves the assignment intact.
