### PR TITLE
docs: clarify how to disable a forced RuboCop cop for HAML files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 * Document that `RuboCop`'s `ignored_cops` is the way to disable a forced cop for HAML files, since `Enabled: false` in `.rubocop.yml` is overridden by the forced configuration
+* Move the RuboCop documentation into a dedicated [RuboCop integration](lib/haml_lint/linter/RuboCop.md) page and document known false positives with `Rails/*` cops in views (e.g. `Rails/FindEach`, `Rails/HttpStatus`)
 
 ### 0.73.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HAML-Lint Changelog
 
+### Unreleased
+
+* Document that `RuboCop`'s `ignored_cops` is the way to disable a forced cop for HAML files, since `Enabled: false` in `.rubocop.yml` is overridden by the forced configuration
+
 ### 0.73.0
 
 * Relax `parallel` dependency from `~> 1.10` to `>= 1.10`

--- a/config/default.yml
+++ b/config/default.yml
@@ -88,8 +88,10 @@ linters:
 
   RuboCop:
     enabled: true
-    # Users can ignore cops using this configuration instead of editing their rubocop configuration.
-    # Mostly there for backward compatibility.
+    # Cops listed here are skipped entirely (passed to RuboCop via `--except`), both when
+    # reporting and when auto-correcting. This is the way to disable a cop only for HAML files,
+    # and the only way to disable a forced cop (see config/forced_rubocop_config.yml), since the
+    # forced configuration always overrides `Enabled: false` set in your own .rubocop.yml.
     ignored_cops: []
 
   RubyComments:

--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -600,8 +600,25 @@ your `.rubocop.yml` files just as you would for a Ruby file. So you can do
 The simplest way of doing configurations for HAML would be to have a distinct
 .rubocop.yml in your `view` directory.
 
-Alternatively, you can ignored some Cop only for HamlLint using the `ignored_cop`
-option to the RuboCop linter (in your `.haml-lint.yml` configuration).
+#### Disabling a cop for HAML files
+
+Because the [forced configurations](/config/forced_rubocop_config.yml) always
+take precedence over your `.rubocop.yml`, setting `Enabled: false` there for a
+forced cop (such as `Layout/CaseIndentation`) has **no effect**. To turn such a
+cop off for HAML files, use the `ignored_cops` option of the RuboCop linter in
+your `.haml-lint.yml`:
+
+```yaml
+linters:
+  RuboCop:
+    ignored_cops:
+      - Layout/CaseIndentation
+```
+
+This passes the cops to RuboCop via `--except`, so they are skipped entirely
+(both when reporting and when auto-correcting), regardless of the forced
+configuration. The same option also works for any non-forced cop you want to
+ignore only for HAML.
 
 You can also explicitly set which RuboCop configuration to use via the
 `HAML_LINT_RUBOCOP_CONF` environment variable. This is intended to be used

--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -570,71 +570,13 @@ Option         | Description
 ---------------|--------------------------------------------
 `ignored_cops` | Array of RuboCop cops to ignore.
 
-This linter integrates with [RuboCop](https://github.com/rubocop-hq/rubocop)
-(a static code analyzer and style enforcer) to check the actual Ruby code in
-your templates.
+Integrates with [RuboCop](https://github.com/rubocop/rubocop) to check the Ruby
+code embedded in your templates, including auto-correction that is fed back into
+the template. This is the most configurable linter in `haml-lint`, with its own
+forced configurations, ways to disable individual cops, and known false-positive
+caveats.
 
-```haml
--# example.haml
-- name = 'James Brown'
-- unused_variable = 42
-
-%p Hello #{name}!
-```
-
-**Output from `haml-lint`**
-```
-example.haml:3 [W] Useless assignment to variable - unused_variable
-```
-
-This linter will respect any RuboCop-specific configuration you have
-set in your `.rubocop.yml` files, but will overwrite some configuration that
-are required to format Ruby code similarly to HAML code.
-
-Here are the [forced configurations](/config/forced_rubocop_config.yml).
-
-You can reference to HAML files for things such as "Exclude" configuration in
-your `.rubocop.yml` files just as you would for a Ruby file. So you can do
-`Exclude: [foo.haml]`.
-
-The simplest way of doing configurations for HAML would be to have a distinct
-.rubocop.yml in your `view` directory.
-
-#### Disabling a cop for HAML files
-
-Because the [forced configurations](/config/forced_rubocop_config.yml) always
-take precedence over your `.rubocop.yml`, setting `Enabled: false` there for a
-forced cop (such as `Layout/CaseIndentation`) has **no effect**. To turn such a
-cop off for HAML files, use the `ignored_cops` option of the RuboCop linter in
-your `.haml-lint.yml`:
-
-```yaml
-linters:
-  RuboCop:
-    ignored_cops:
-      - Layout/CaseIndentation
-```
-
-This passes the cops to RuboCop via `--except`, so they are skipped entirely
-(both when reporting and when auto-correcting), regardless of the forced
-configuration. The same option also works for any non-forced cop you want to
-ignore only for HAML.
-
-You can also explicitly set which RuboCop configuration to use via the
-`HAML_LINT_RUBOCOP_CONF` environment variable. This is intended to be used
-by external tools which run the linter on files in temporary directories
-separate from the directory where the HAML template originally resided (and
-thus where the normal `.rubocop.yml` would be ignored picked up).
-
-### Displaying Cop Names
-
-You can display the name of the cop by adding the following to your
-`.rubocop.yml` configuration:
-
-```yaml
-AllCops:
-  DisplayCopNames: true
-```
+See **[RuboCop integration](RuboCop.md)** for full documentation.
 
 ## RubyComments
 

--- a/lib/haml_lint/linter/RuboCop.md
+++ b/lib/haml_lint/linter/RuboCop.md
@@ -1,0 +1,128 @@
+# RuboCop integration
+
+The `RuboCop` linter integrates with
+[RuboCop](https://github.com/rubocop/rubocop) (a static code analyzer and style
+enforcer) to check the actual Ruby code embedded in your templates. Rather than
+running RuboCop on the `.haml` file directly, `haml-lint` reconstructs a valid
+Ruby file from the Ruby fragments scattered through the template and runs RuboCop
+on that — including auto-correction that is fed back into the template. See the
+[Ruby extraction internals](/lib/haml_lint/ruby_extraction/README.md) if you want
+to understand how that works.
+
+```haml
+-# example.haml
+- name = 'James Brown'
+- unused_variable = 42
+
+%p Hello #{name}!
+```
+
+**Output from `haml-lint`**
+
+```
+example.haml:3 [W] Useless assignment to variable - unused_variable
+```
+
+| Option         | Description                      |
+| -------------- | -------------------------------- |
+| `ignored_cops` | Array of RuboCop cops to ignore. |
+
+## Configuration
+
+This linter respects any RuboCop-specific configuration you have set in your
+`.rubocop.yml` files, but it overwrites some configuration that is required to
+format Ruby code similarly to HAML code. Here are the
+[forced configurations](/config/forced_rubocop_config.yml).
+
+You can reference HAML files for things such as `Exclude` configuration in your
+`.rubocop.yml` files just as you would for a Ruby file, so you can do
+`Exclude: [foo.haml]`. The simplest way of configuring RuboCop for HAML is to
+have a distinct `.rubocop.yml` in your `views` directory.
+
+You can also explicitly set which RuboCop configuration to use via the
+`HAML_LINT_RUBOCOP_CONF` environment variable. This is intended to be used by
+external tools which run the linter on files in temporary directories separate
+from the directory where the HAML template originally resided (and thus where the
+normal `.rubocop.yml` would not be picked up).
+
+## Disabling a cop for HAML files
+
+Because the [forced configurations](/config/forced_rubocop_config.yml) always
+take precedence over your `.rubocop.yml`, setting `Enabled: false` there for a
+forced cop (such as `Layout/CaseIndentation`) has **no effect**. To turn such a
+cop off for HAML files, use the `ignored_cops` option of the RuboCop linter in
+your `.haml-lint.yml`:
+
+```yaml
+linters:
+  RuboCop:
+    ignored_cops:
+      - Layout/CaseIndentation
+```
+
+This passes the cops to RuboCop via `--except`, so they are skipped entirely
+(both when reporting and when auto-correcting), regardless of the forced
+configuration. The same option also works for any non-forced cop you want to
+ignore only for HAML.
+
+## Known false positives with Rails cops
+
+When you use [rubocop-rails](https://github.com/rubocop/rubocop-rails), some
+`Rails/*` cops assume they are running inside a controller or model and report
+offenses that do not apply to view code. Because `haml-lint` runs RuboCop on the
+Ruby extracted from your templates, these cops can fire — and "fixing" them may
+introduce bugs. A couple of known cases:
+
+- **`Rails/FindEach`** — flags `each` on an ActiveRecord relation and suggests
+  `find_each`. In a view the collection has usually already been ordered (in the
+  controller, a scope, or a default scope), and `find_each` ignores ordering: it
+  loads records in batches ordered by primary key. Applying the correction
+  silently changes the order in which records are rendered.
+
+  ```haml
+  %ul
+    - @cities.includes(:country).each do |city|
+      %li #{city} (#{city.country})
+  ```
+
+  ```
+  test.haml:2 [W] RuboCop: Rails/FindEach: Use `find_each` instead of `each`.
+  ```
+
+- **`Rails/HttpStatus`** — interprets a `status:` keyword as an HTTP status code,
+  so `= render 'partial', status: 'future'` is reported as
+  `Prefer nil over future to define HTTP status code.` even though `status` here
+  is just a local passed to the partial.
+
+Since you control which cops run (by loading `rubocop-rails` and enabling them),
+the recommended fix is to disable the offending cop for HAML files. You can use
+the `ignored_cops` option described above:
+
+```yaml
+linters:
+  RuboCop:
+    ignored_cops:
+      - Rails/FindEach
+      - Rails/HttpStatus
+```
+
+or scope it from your `.rubocop.yml` with an `Exclude` on `.haml` files:
+
+```yaml
+Rails/FindEach:
+  Exclude:
+    - "**/*.haml"
+```
+
+This list is not exhaustive — any cop that relies on controller/model context
+may behave the same way in views.
+
+## Displaying cop names
+
+You can display the name of the cop by adding the following to your
+`.rubocop.yml` configuration:
+
+```yaml
+AllCops:
+  DisplayCopNames: true
+```


### PR DESCRIPTION
Closes #407
Closes #488
Refs #443

## Summary

This PR pulls all RuboCop-integration documentation into one place and fills two gaps that have tripped users up.

**Disabling a forced cop (#407).** Setting `Enabled: false` for a forced RuboCop cop (such as `Layout/CaseIndentation`) in your own `.rubocop.yml` has no effect, because haml-lint's forced configuration (`config/forced_rubocop_config.yml`) always takes precedence. Users reach for the intuitive `.rubocop.yml` toggle, it silently does nothing, and there is no clear pointer to the option that actually works. The escape hatch already exists: the RuboCop linter's `ignored_cops` option (in `.haml-lint.yml`) passes the cop to RuboCop via `--except`, so it is skipped entirely, both when reporting and when auto-correcting, regardless of the forced config. This PR just makes that discoverable.

**Rails `Rails/*` false positives (#488, refs #443).** Because haml-lint runs RuboCop on the Ruby extracted from templates, some `rubocop-rails` cops that assume a controller/model context misfire on view code. The two documented cases:

- `Rails/FindEach` suggests `find_each` on a relation that was usually already
  ordered elsewhere (controller, scope, default scope); `find_each` ignores the
  order and loads by primary key, silently changing render order.
- `Rails/HttpStatus` treats a partial's `status:` keyword as an HTTP status code.

The maintainer already confirmed in #443 that `Rails/HttpStatus` "is clearly not meant to be run on views" but that haml-lint cannot reliably detect this, so the right answer is documentation plus the `ignored_cops` / `.rubocop.yml` `Exclude` escape hatch, not a behavior change.

No behavior or API changes.

## Changes

- Add a dedicated `lib/haml_lint/linter/RuboCop.md` page covering the whole integration: overview, configuration, disabling a cop for HAML files (`ignored_cops`), known false positives with `Rails/*` cops, and displaying cop names.
- Shrink the `## RuboCop` entry in `lib/haml_lint/linter/README.md` to a short stub linking to the new page (the catalog `#rubocop` anchor is preserved), and fix the `ignored_cop` typo.
- Update the `ignored_cops` comment in `config/default.yml` to describe its real purpose (instead of "mostly there for backward compatibility").
- Add CHANGELOG entries.

## Verification

- **#407**: On a nested `case`/`when` example, the forced config reports 2
  `Layout/CaseIndentation` offenses; with the cop listed under
  `linters.RuboCop.ignored_cops` it reports 0. Setting `Enabled: false` in
  `.rubocop.yml` leaves the 2 offenses in place, confirming why users could not
  disable it.
- **#488**: Reproduced `Rails/HttpStatus` with `rubocop-rails` loaded.
  `render 'partial', status: 'future'` is flagged as
  `Rails/HttpStatus: Prefer nil over future to define HTTP status code.` and is
  reported as autocorrectable, i.e. `haml-lint -A` would rewrite the local to
  `nil`. This is the false positive the new section documents.
