### PR TITLE
Stop testing on Ruby 3.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - "3.2"
           - "3.3"
           - "3.4"
           - "4.0"


### PR DESCRIPTION
This reached EOL on March 31 2026.
