### PR TITLE
Attempt fix JRuby parallel linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,7 @@
 
 ### Unreleased
 
-* Fix `UnnecessaryStringOutput` false positives
-* Fix `Layout/EmptyLineAfterGuardClause` false positive for a blank line at the end of a `:ruby` filter
-* Fix `RuboCop` lints being reported on the wrong line when the same file is
   linted more than once, by no longer reusing RuboCop's result cache (#593)
-* Add `UnescapedHtml` linter to flag use of `!=`/`!~`/`!` unescaped HTML output
-* Fix `LineLength` not being disabled by `haml-lint:disable` comments inside filter blocks such as `:javascript` and `:css`
-* Fix RuboCop reporting a false `Lint/UselessAssignment`
-* Keep the file, line, and linter name in the `github` reporter's log output
 * Add auto-correction (`-a`/`--auto-correct` and `-A`/`--auto-correct-all`) to HAML-level linters.
   * Safe corrections (run under both `-a` and `-A`): `ClassAttributeWithStaticValue`,
     `ClassesBeforeIds`, `EmptyObjectReference`, `FinalNewline`,
@@ -17,6 +10,14 @@
     `SpaceInsideHashAttributes`, `TagName`, `TrailingEmptyLines`, `TrailingWhitespace`, and
     `UnnecessaryInterpolation`.
   * Unsafe corrections (run only under `-A`): `ConsecutiveComments`, `EmptyScript`, and `MultilineScript`
+* Keep the file, line, and linter name in the `github` reporter's log output
+* Fix RuboCop reporting a false `Lint/UselessAssignment`
+* Fix `LineLength` not being disabled by `haml-lint:disable` comments inside filter blocks such as `:javascript` and `:css`
+* Add `UnescapedHtml` linter to flag use of `!=`/`!~`/`!` unescaped HTML output
+* Fix `RuboCop` lints being reported on the wrong line when the same file is
+* Fix `Layout/EmptyLineAfterGuardClause` false positive for a blank line at the end of a `:ruby` filter
+* Fix `UnnecessaryStringOutput` false positives
+* Fix cached path handling in parallelized runs under JRuby
 
 ### 0.73.0
 

--- a/lib/haml_lint/runner.rb
+++ b/lib/haml_lint/runner.rb
@@ -23,7 +23,8 @@ module HamlLint
     def run(options = {})
       @config = load_applicable_config(options)
       @sources = extract_applicable_sources(config, options)
-      @linter_selector = HamlLint::LinterSelector.new(config, options)
+      @options = options
+      @linter_selector = build_linter_selector
       @fail_fast = options.fetch(:fail_fast, false)
       @cache = {}
       @autocorrect = options[:autocorrect]
@@ -60,6 +61,17 @@ module HamlLint
     #
     # @return [HamlLint::LinterSelector]
     attr_reader :linter_selector
+
+    # Returns a fresh selector for this run.
+    #
+    # LinterSelector memoizes linter instances, and linters mutate instance
+    # state while processing a document. JRuby runs Parallel.map in threads, so
+    # parallel jobs must not share a selector.
+    #
+    # @return [HamlLint::LinterSelector]
+    def build_linter_selector
+      HamlLint::LinterSelector.new(config, @options)
+    end
 
     # Returns the {HamlLint::Configuration} that should be used given the
     # specified options.
@@ -193,7 +205,7 @@ module HamlLint
     # @return [void]
     def warm_cache
       results = Parallel.map(sources) do |source|
-        lints = collect_lints(source, linter_selector, config)
+        lints = collect_lints(source, build_linter_selector, config)
         [source.path, lints]
       end
       @cache = results.to_h

--- a/lib/haml_lint/source.rb
+++ b/lib/haml_lint/source.rb
@@ -13,12 +13,13 @@ module HamlLint
     # @param [IO] io
     def initialize(path: nil, io: nil)
       @path = path
+      @file_path = File.expand_path(path) if path
       @io = io
     end
 
     # @return [String] Contents of the given IO object.
     def contents
-      @contents ||= @io&.read || File.read(path)
+      @contents ||= @io&.read || File.read(@file_path)
     end
   end
 end

--- a/spec/haml_lint/runner_spec.rb
+++ b/spec/haml_lint/runner_spec.rb
@@ -92,6 +92,22 @@ describe HamlLint::Runner do
           subject
         end
 
+        context 'with multiple files' do
+          let(:options) { base_options.merge(parallel: true, files: %w[example.haml other.haml]) }
+
+          before do
+            File.write('other.haml', "%p hello\n")
+            Parallel.stub(:map) do |sources, &block|
+              sources.map { |source| block.call(source) }
+            end
+          end
+
+          it 'builds a fresh linter selector for each parallel job' do
+            runner.should_receive(:build_linter_selector).exactly(3).times.and_call_original
+            subject
+          end
+        end
+
         context 'when errors are present' do
           it 'successfully reports those errors' do
             expect(subject.lints.first.message).to match(/Avoid defining `class` in attributes hash/)

--- a/spec/haml_lint/source_spec.rb
+++ b/spec/haml_lint/source_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+describe HamlLint::Source do
+  describe '#contents' do
+    include_context 'isolated environment'
+
+    before do
+      File.write('example.haml', "%p hello\n")
+      Dir.mkdir('other')
+    end
+
+    it 'reads from the original file location if the working directory changes' do
+      source = described_class.new(path: 'example.haml')
+
+      Dir.chdir('other') do
+        source.contents.should == "%p hello\n"
+      end
+    end
+  end
+end


### PR DESCRIPTION
We were not able to reproduce the issue, but based on the reported error this is an attempt at a fix.

- Read source files through stable absolute paths, since RuboCop changes working directories
- Avoid sharing memoized linter instances across parallel jobs
- Add regression coverage for both behaviors

While here, update the changelog with the correct order that changes were merged.

Fixes #559