### PR TITLE
Reuse selectors per parallel worker

### DIFF
--- a/lib/haml_lint/runner.rb
+++ b/lib/haml_lint/runner.rb
@@ -62,6 +62,8 @@ module HamlLint
     # @return [HamlLint::LinterSelector]
     attr_reader :linter_selector
 
+    PARALLEL_LINTER_SELECTOR_THREAD_KEY = :haml_lint_runner_parallel_linter_selectors
+
     # Returns a fresh selector for this run.
     #
     # LinterSelector memoizes linter instances, and linters mutate instance
@@ -71,6 +73,18 @@ module HamlLint
     # @return [HamlLint::LinterSelector]
     def build_linter_selector
       HamlLint::LinterSelector.new(config, @options)
+    end
+
+    # Returns a selector scoped to the current parallel worker.
+    #
+    # MRI runs Parallel.map in forked processes, so each worker can safely reuse
+    # its own linter instances. JRuby runs Parallel.map in threads, so this must
+    # be isolated per thread to avoid sharing mutable linter state.
+    #
+    # @return [HamlLint::LinterSelector]
+    def parallel_linter_selector
+      selectors = Thread.current[PARALLEL_LINTER_SELECTOR_THREAD_KEY] ||= {}.compare_by_identity
+      selectors[self] ||= build_linter_selector
     end
 
     # Returns the {HamlLint::Configuration} that should be used given the
@@ -205,7 +219,7 @@ module HamlLint
     # @return [void]
     def warm_cache
       results = Parallel.map(sources) do |source|
-        lints = collect_lints(source, build_linter_selector, config)
+        lints = collect_lints(source, parallel_linter_selector, config)
         [source.path, lints]
       end
       @cache = results.to_h

--- a/spec/haml_lint/runner_spec.rb
+++ b/spec/haml_lint/runner_spec.rb
@@ -92,17 +92,25 @@ describe HamlLint::Runner do
           subject
         end
 
-        context 'with multiple files' do
-          let(:options) { base_options.merge(parallel: true, files: %w[example.haml other.haml]) }
+        context 'with multiple files handled by fewer parallel workers' do
+          let(:options) do
+            base_options.merge(parallel: true,
+                               files: %w[example.haml other.haml third.haml fourth.haml])
+          end
 
           before do
-            File.write('other.haml', "%p hello\n")
+            %w[other.haml third.haml fourth.haml].each do |file|
+              File.write(file, "%p hello\n")
+            end
+
             Parallel.stub(:map) do |sources, &block|
-              sources.map { |source| block.call(source) }
+              sources.each_slice(2).map do |worker_sources|
+                Thread.new { worker_sources.map { |source| block.call(source) } }
+              end.flat_map(&:value)
             end
           end
 
-          it 'builds a fresh linter selector for each parallel job' do
+          it 'builds a fresh linter selector for each parallel worker' do
             runner.should_receive(:build_linter_selector).exactly(3).times.and_call_original
             subject
           end


### PR DESCRIPTION
We accidentally introduced a performance regression in #663.

- Restore per-worker linter reuse for MRI process-based parallelism
- Keep JRuby thread safety by scoping selectors to each worker thread
- Cover multiple files handled by fewer parallel workers

Fixes #668