### PR TITLE
Fix RuboCop config warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -83,11 +83,6 @@ Style/PercentLiteralDelimiters:
     '%W': '[]'
     '%x': '{}'
 
-# Renaming `has_something?` to `something?` obfuscates whether it is a "is-a" or
-# a "has-a" relationship.
-Naming/PredicateName:
-  Enabled: false
-
 Style/SignalException:
   Enabled: false
 

--- a/lib/haml_lint/spec/matchers/report_lint.rb
+++ b/lib/haml_lint/spec/matchers/report_lint.rb
@@ -65,7 +65,7 @@ module HamlLint
             (expected_severity ? " with severity '#{expected_severity}'" : '')
         end
 
-        def has_lints?(linter, expected_line, count, expected_message, expected_severity, # rubocop:disable Metrics/ParameterLists
+        def has_lints?(linter, expected_line, count, expected_message, expected_severity, # rubocop:disable Metrics/ParameterLists,Naming
                        expected_corrected)
           if expected_line
             has_expected_line_lints?(linter,
@@ -83,7 +83,7 @@ module HamlLint
           end
         end
 
-        def has_expected_line_lints?(linter, # rubocop:disable Metrics/ParameterLists
+        def has_expected_line_lints?(linter, # rubocop:disable Metrics/ParameterLists,Naming
                                      expected_line,
                                      count,
                                      expected_message,

--- a/lib/haml_lint/tree/haml_comment_node.rb
+++ b/lib/haml_lint/tree/haml_comment_node.rb
@@ -28,7 +28,7 @@ module HamlLint::Tree
     # Returns whether this comment contains a `locals` directive.
     #
     # @return [Boolean]
-    def is_strict_locals?
+    def is_strict_locals? # rubocop:disable Naming
       text.lstrip.start_with?('locals:')
     end
 

--- a/lib/haml_lint/tree/tag_node.rb
+++ b/lib/haml_lint/tree/tag_node.rb
@@ -46,7 +46,7 @@ module HamlLint::Tree
     # Returns whether this tag has a specified attribute.
     #
     # @return [true,false]
-    def has_hash_attribute?(attribute)
+    def has_hash_attribute?(attribute) # rubocop:disable Naming
       hash_attributes? && existing_attributes.include?(attribute)
     end
 

--- a/lib/haml_lint/utils.rb
+++ b/lib/haml_lint/utils.rb
@@ -233,7 +233,7 @@ module HamlLint
 
     # Returns true if line is only whitespace.
     # Note, this is not like blank? is rails. For nil, this returns false.
-    def is_blank_line?(line)
+    def is_blank_line?(line) # rubocop:disable Naming
       line && line.index(/\S/).nil?
     end
 


### PR DESCRIPTION
Remove the global obsolete `Naming/PredicateName` RuboCop config that produced unparsable Overcommit output. Keep the existing predicate method names via targeted `rubocop:disable Naming` directives that work with both RuboCop 1.0 and current RuboCop.