### PR TITLE
Add unsafe autocorrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Haml-Lint Changelog
 
+### Unreleased
+
+* Add unsafe auto-correction (run only under `-A`/`--auto-correct-all`) to `UnnecessaryStringOutput`, `HtmlAttributes`, `ConsecutiveSilentScripts`, and `AlignmentTabs`
+* Fix `AlignmentTabs` never running, as it was missing its `LinterRegistry` registration
+* Fix `ConsecutiveSilentScripts` reporting overlapping duplicate lints for a run of more than `max_consecutive + 1` scripts
+
 ### 0.75.0
 
 * Fix performance regression when using `--parallel` flag

--- a/lib/haml_lint/linter/alignment_tabs.rb
+++ b/lib/haml_lint/linter/alignment_tabs.rb
@@ -3,12 +3,29 @@
 module HamlLint
   # Checks for tabs that are placed for alignment of tag content
   class Linter::AlignmentTabs < Linter
+    include LinterRegistry
+
+    supports_autocorrect(true)
+    autocorrect_safe(false)
+
     REGEX = /[^\s*]\t+/
+    # Same as +REGEX+, but captures the character preceding the alignment tabs
+    # so it can be kept while the tabs themselves are collapsed to a space.
+    CORRECTION_REGEX = /([^\s*])\t+/
 
     def visit_tag(node)
-      if REGEX.match?(node.source_code)
-        record_lint(node, 'Avoid using tabs for alignment')
-      end
+      return unless REGEX.match?(node.source_code)
+
+      record_lint(node, 'Avoid using tabs for alignment', corrected: correct(node))
+    end
+
+    private
+
+    # @return [Boolean] whether a correction was applied
+    def correct(node)
+      index = node.line - 1
+      line = autocorrected_lines[index]
+      correct_line(index, line.gsub(CORRECTION_REGEX) { "#{::Regexp.last_match(1)} " })
     end
   end
 end

--- a/lib/haml_lint/linter/consecutive_silent_scripts.rb
+++ b/lib/haml_lint/linter/consecutive_silent_scripts.rb
@@ -6,6 +6,9 @@ module HamlLint
   class Linter::ConsecutiveSilentScripts < Linter
     include LinterRegistry
 
+    supports_autocorrect(true)
+    autocorrect_safe(false)
+
     SILENT_SCRIPT_DETECTOR = ->(child) do
       child.type == :silent_script && child.children.empty?
     end
@@ -18,10 +21,19 @@ module HamlLint
         SILENT_SCRIPT_DETECTOR,
         config['max_consecutive'] + 1,
       ) do |group|
+        reported_nodes.concat(group)
         record_lint(group.first,
                     "#{group.count} consecutive Ruby scripts can be merged " \
-                    'into a single `:ruby` filter')
+                    'into a single `:ruby` filter',
+                    corrected: collect_merge(group))
       end
+    end
+
+    def after_visit_root(_node)
+      super
+      return if merges.empty?
+
+      apply_autocorrect(merged_source)
     end
 
     private
@@ -36,6 +48,61 @@ module HamlLint
 
     def reported_nodes
       @reported_nodes ||= []
+    end
+
+    def reset_autocorrect_state
+      super
+      @merges = []
+    end
+
+    # Queues a group of consecutive silent scripts to be replaced by an
+    # equivalent `:ruby` filter block. Skips (and reports without correcting)
+    # groups that aren't a run of single-line scripts on contiguous lines.
+    #
+    # @return [Boolean] whether a correction was queued
+    def collect_merge(group)
+      return false unless autocorrect?
+      return false unless mergeable?(group)
+
+      merges << {
+        start: group.first.line - 1,
+        finish: group.last.line - 1,
+        lines: ruby_filter_lines(group),
+      }
+      true
+    end
+
+    # @return [Boolean] whether every script is a single line and the group
+    #   occupies a contiguous run of lines
+    def mergeable?(group)
+      group.none? { |node| node.script.include?("\n") } &&
+        group.each_cons(2).all? { |a, b| b.line == a.line + 1 }
+    end
+
+    # Builds the replacement lines: a `:ruby` filter marker at the group's
+    # indentation, followed by each script's body indented one level deeper.
+    #
+    # @return [Array<String>]
+    def ruby_filter_lines(group)
+      indent = document.source_lines[group.first.line - 1][/\A\s*/]
+      inner = indent + (indent.include?("\t") ? "\t" : '  ')
+      ["#{indent}:ruby", *group.map { |node| "#{inner}#{node.script.strip}" }]
+    end
+
+    # Applies the queued range replacements from the bottom up (so earlier line
+    # indices stay valid) and returns the rebuilt source.
+    #
+    # @return [String]
+    def merged_source
+      lines = document.source_lines.dup
+      merges.sort_by { |merge| -merge[:start] }.each do |merge|
+        lines[merge[:start]..merge[:finish]] = merge[:lines]
+      end
+      lines.join("\n")
+    end
+
+    def merges
+      @merges ||= []
     end
   end
 end

--- a/lib/haml_lint/linter/html_attributes.rb
+++ b/lib/haml_lint/linter/html_attributes.rb
@@ -6,11 +6,80 @@ module HamlLint
   class Linter::HtmlAttributes < Linter
     include LinterRegistry
 
+    supports_autocorrect(true)
+    autocorrect_safe(false)
+
+    MESSAGE = "Prefer the hash attributes syntax (%tag{ lang: 'en' }) " \
+              'over HTML attributes syntax (%tag(lang=en))'
+
     def visit_tag(node)
       return unless node.html_attributes?
 
-      record_lint(node, "Prefer the hash attributes syntax (%tag{ lang: 'en' }) " \
-                        'over HTML attributes syntax (%tag(lang=en))')
+      record_lint(node, MESSAGE, corrected: correct(node))
+    end
+
+    private
+
+    # Rewrites the HTML attribute group `(...)` as a Ruby hash group `{...}`,
+    # preserving each attribute's value (static strings, booleans, and Ruby
+    # expressions alike).
+    #
+    # The conversion is skipped (the lint is still reported) when it can't be
+    # performed losslessly: when the tag already has a `{...}` hash group, when
+    # the `.class`/`#id` shorthand is present (its `class`/`id` are merged into
+    # the parsed attributes and can't be told apart from the HTML ones), or when
+    # the attribute list spans multiple lines.
+    #
+    # @return [Boolean] whether a correction was applied
+    def correct(node)
+      return false unless correctable?(node)
+      return false unless pairs = hash_pairs(node)
+
+      hash_source = "{ #{pairs.join(', ')} }"
+      return false unless parse_ruby(hash_source)
+
+      index = node.line - 1
+      line = autocorrected_lines[index]
+      html_source = node.dynamic_attributes_source[:html]
+      return false unless line.include?(html_source)
+
+      correct_line(index, line.sub(html_source) { hash_source })
+    end
+
+    # Whether the tag's HTML attributes can be losslessly converted in place.
+    #
+    # @return [Boolean]
+    def correctable?(node)
+      return false if node.hash_attributes?
+      return false unless node.static_attributes_source.empty?
+
+      html_source = node.dynamic_attributes_source[:html]
+      !html_source.nil? && !html_source.include?("\n")
+    end
+
+    # Builds the `key => value` fragments for the tag's HTML attributes, or +nil+
+    # when one of the static values can't be safely serialized.
+    #
+    # @return [Array<String>, nil]
+    def hash_pairs(node)
+      pairs = node.static_attributes.map do |key, value|
+        return nil unless serializable?(value)
+
+        "#{key.inspect} => #{value.inspect}"
+      end
+
+      node.dynamic_attributes_sources.each do |literal|
+        inner = literal.strip.delete_prefix('{').delete_suffix('}').sub(/,\s*\z/, '').strip
+        pairs << inner unless inner.empty?
+      end
+
+      pairs
+    end
+
+    # @return [Boolean] whether the static attribute value round-trips through
+    #   +#inspect+ as a Ruby literal
+    def serializable?(value)
+      value.is_a?(String) || [true, false, nil].include?(value) || value.is_a?(Numeric)
     end
   end
 end

--- a/lib/haml_lint/linter/unnecessary_string_output.rb
+++ b/lib/haml_lint/linter/unnecessary_string_output.rb
@@ -11,35 +11,99 @@ module HamlLint
   class Linter::UnnecessaryStringOutput < Linter
     include LinterRegistry
 
+    supports_autocorrect(true)
+    autocorrect_safe(false)
+
     MESSAGE = '`= "..."` should be rewritten as `...`'
 
     def visit_tag(node)
-      if tag_has_inline_script?(node) && inline_content_is_string?(node)
-        record_lint(node, MESSAGE)
-      end
+      return unless tag_has_inline_script?(node) && inline_content_is_string?(node)
+
+      plain = safe_plain_text(node.script)
+      corrected = plain ? correct_tag(node, plain) : false
+      record_lint(node, MESSAGE, corrected: corrected)
     end
 
     def visit_script(node)
       # Some script nodes created by the Haml parser aren't actually script
       # nodes declared via the `=` marker. Check for it.
       return unless /\A\s*=/.match?(node.source_code)
+      return unless plain = safe_plain_text(node.script)
 
-      if outputs_string_literal?(node)
-        record_lint(node, MESSAGE)
-      end
+      record_lint(node, MESSAGE, corrected: correct_script(node, plain))
     end
 
     private
 
-    def outputs_string_literal?(script_node)
-      return unless tree = parse_ruby(script_node.script)
-      return unless %i[str dstr].include?(tree.type)
+    # Rewrites `%tag= "..."` as `%tag ...`, dropping the `=` marker and the
+    # surrounding quotes.
+    #
+    # @return [Boolean] whether a correction was applied
+    def correct_tag(node, plain)
+      marker = node.inline_marker_source.rstrip
+      # Only unwrap plain escaped output (`= "..."`); leave `!=`, `~`, and the
+      # whitespace-removal markers (`<`/`>`) untouched, as they change rendering.
+      return false unless /\A=\s*["']/.match?(marker)
 
+      index = node.line - 1
+      line = autocorrected_lines[index]
+      return false unless line.rstrip.end_with?(marker)
+
+      prefix = line.rstrip[0...(line.rstrip.length - marker.length)]
+      correct_line(index, "#{prefix} #{plain}")
+    end
+
+    # Rewrites a standalone `= "..."` script as plain text, preserving the
+    # node's indentation.
+    #
+    # @return [Boolean] whether a correction was applied
+    def correct_script(node, plain)
+      index = node.line - 1
+      line = autocorrected_lines[index]
+      indentation = line[/\A\s*/]
+      correct_line(index, "#{indentation}#{plain}")
+    end
+
+    # Returns the Haml plain-text equivalent of a Ruby string literal script, or
+    # +nil+ when the script is not a string literal that can be safely unwrapped
+    # (i.e. unwrapping would change the rendered output).
+    #
+    # @return [String, nil]
+    def safe_plain_text(script)
+      return if script.include?("\n")
+      return unless tree = parse_ruby(script)
+      return unless %i[str dstr].include?(tree.type)
+      return unless safely_unwrappable?(tree)
+
+      plain_text_from(tree)
+    rescue ::Parser::SyntaxError
+      # Gracefully ignore syntax errors, as that's managed by a different linter
+      nil
+    end
+
+    # Whether unwrapping the string literal into Haml plain text would preserve
+    # the rendered output.
+    #
+    # @return [Boolean]
+    def safely_unwrappable?(tree)
       !starts_with_reserved_character?(tree.children.first) &&
         !contains_escape_sequence?(tree) &&
         !contains_significant_whitespace?(tree)
-    rescue ::Parser::SyntaxError
-      # Gracefully ignore syntax errors, as that's managed by a different linter
+    end
+
+    # Reconstructs the Haml plain-text form of a string literal. Literal segments
+    # keep their text (with any `#{` escaped so Haml won't interpolate it), while
+    # interpolation segments are emitted verbatim in their `#{...}` form.
+    #
+    # @return [String]
+    def plain_text_from(tree)
+      string_segments(tree).map do |segment|
+        if segment.type == :str
+          segment.children.first.gsub('#{') { '\#{' }
+        else
+          segment.location.expression.source
+        end
+      end.join
     end
 
     # Returns whether a string starts with a character that would otherwise be

--- a/lib/haml_lint/tree/tag_node.rb
+++ b/lib/haml_lint/tree/tag_node.rb
@@ -155,6 +155,18 @@ module HamlLint::Tree
       dynamic_attributes_source[:html][/\A\((.*)\)\z/, 1] if html_attributes?
     end
 
+    # The tag's static (non-Ruby) attributes parsed into a Ruby hash. Keys are
+    # strings and values are their literal parsed values (e.g. `true` for a
+    # boolean attribute such as `(required)`).
+    #
+    # @note When the tag uses the `.class`/`#id` shorthand, the resulting
+    #   `class`/`id` entries are merged into this hash as well.
+    #
+    # @return [Hash]
+    def static_attributes
+      @value[:attributes]
+    end
+
     # ID of the HTML tag.
     #
     # @return [String]

--- a/spec/haml_lint/linter/alignment_tabs_spec.rb
+++ b/spec/haml_lint/linter/alignment_tabs_spec.rb
@@ -26,4 +26,61 @@ RSpec.describe HamlLint::Linter::AlignmentTabs do
       it { should report_lint line: 3 }
     end
   end
+
+  context 'with autocorrect' do
+    let(:autocorrect) { :all }
+
+    context 'when a tag uses tabs for alignment' do
+      let(:haml) { "%p\tHello" }
+
+      it 'collapses the tabs into a single space' do
+        subject
+        document.source.should == '%p Hello'
+      end
+
+      it 'records the lint as corrected' do
+        subject
+        subject.lints.size.should == 1
+        subject.lints.first.corrected.should == true
+      end
+    end
+
+    context 'when the tag uses tabs for indentation as well' do
+      let(:haml) { "%p\n\t%span Hello\n\t%span\tworld" }
+
+      it 'only collapses the alignment tabs, keeping indentation tabs' do
+        subject
+        document.source.should == "%p\n\t%span Hello\n\t%span world"
+      end
+    end
+
+    context 'under :safe mode' do
+      let(:autocorrect) { :safe }
+      let(:haml) { "%p\tHello" }
+
+      it 'reports the lint but does not correct it' do
+        subject
+        subject.lints.first.corrected.should == false
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when there are no alignment tabs' do
+      let(:haml) { '%p Hello' }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the linter is disabled inline' do
+      let(:haml) { "-# haml-lint:disable AlignmentTabs\n%p\tHello" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+  end
 end

--- a/spec/haml_lint/linter/consecutive_silent_scripts_spec.rb
+++ b/spec/haml_lint/linter/consecutive_silent_scripts_spec.rb
@@ -60,4 +60,71 @@ describe HamlLint::Linter::ConsecutiveSilentScripts do
       it { should_not report_lint }
     end
   end
+
+  context 'with autocorrect' do
+    let(:autocorrect) { :all }
+
+    context 'when consecutive scripts are over the limit' do
+      let(:haml) { "- a = 1\n- b = 2\n- c = 3" }
+
+      it 'merges them into a `:ruby` filter block' do
+        subject
+        document.source.should == ":ruby\n  a = 1\n  b = 2\n  c = 3"
+      end
+
+      it 'records a single corrected lint' do
+        subject
+        subject.lints.size.should == 1
+        subject.lints.first.corrected.should == true
+      end
+    end
+
+    context 'when the scripts are nested under a tag' do
+      let(:haml) { "%div\n  - a = 1\n  - b = 2\n  - c = 3" }
+
+      it 'preserves the indentation of the block' do
+        subject
+        document.source.should == "%div\n  :ruby\n    a = 1\n    b = 2\n    c = 3"
+      end
+    end
+
+    context 'when the run is longer than the minimum' do
+      let(:haml) { "- a = 1\n- b = 2\n- c = 3\n- d = 4\n- e = 5" }
+
+      it 'merges the whole run into one block and reports it once' do
+        subject
+        subject.lints.size.should == 1
+        document.source.should == ":ruby\n  a = 1\n  b = 2\n  c = 3\n  d = 4\n  e = 5"
+      end
+    end
+
+    context 'under :safe mode' do
+      let(:autocorrect) { :safe }
+      let(:haml) { "- a = 1\n- b = 2\n- c = 3" }
+
+      it 'reports the lint but does not correct it' do
+        subject
+        subject.lints.first.corrected.should == false
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the scripts are under the limit' do
+      let(:haml) { "- a = 1\n- b = 2" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the linter is disabled inline' do
+      let(:haml) { "-# haml-lint:disable ConsecutiveSilentScripts\n- a = 1\n- b = 2\n- c = 3" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+  end
 end

--- a/spec/haml_lint/linter/html_attributes_spec.rb
+++ b/spec/haml_lint/linter/html_attributes_spec.rb
@@ -26,4 +26,108 @@ describe HamlLint::Linter::HtmlAttributes do
 
     it { should report_lint }
   end
+
+  context 'with autocorrect' do
+    let(:autocorrect) { :all }
+
+    context 'when a tag has a single dynamic HTML attribute' do
+      let(:haml) { '%tag(lang=en)' }
+
+      it 'rewrites it using the hash attributes syntax' do
+        subject
+        document.source.should == '%tag{ "lang" => en }'
+      end
+
+      it 'records the lint as corrected' do
+        subject
+        subject.lints.size.should == 1
+        subject.lints.first.corrected.should == true
+      end
+    end
+
+    context 'when a tag has multiple static HTML attributes' do
+      let(:haml) { '%a(href="x" title="foo")' }
+
+      it 'rewrites all of them' do
+        subject
+        document.source.should == '%a{ "href" => "x", "title" => "foo" }'
+      end
+    end
+
+    context 'when a tag has a boolean HTML attribute' do
+      let(:haml) { '%input(type="text" required)' }
+
+      it 'rewrites the boolean attribute as `true`' do
+        subject
+        document.source.should == '%input{ "type" => "text", "required" => true }'
+      end
+    end
+
+    context 'when a tag mixes static and dynamic HTML attributes' do
+      let(:haml) { '%a(href="x" data=dynamic)' }
+
+      it 'preserves the Ruby expression for the dynamic value' do
+        subject
+        document.source.should == '%a{ "href" => "x", "data" => dynamic }'
+      end
+    end
+
+    context 'when an attribute name contains a dash' do
+      let(:haml) { '%div(data-foo="bar")' }
+
+      it 'keeps the string key' do
+        subject
+        document.source.should == '%div{ "data-foo" => "bar" }'
+      end
+    end
+
+    context 'when the tag uses the class/id shorthand' do
+      let(:haml) { '%div.card(data-x="y")' }
+
+      it 'reports the lint but does not change the source' do
+        subject
+        subject.lints.first.corrected.should == false
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the tag already has a hash attributes group' do
+      let(:haml) { '%tag(lang=en){ attr: value }' }
+
+      it 'reports the lint but does not change the source' do
+        subject
+        subject.lints.first.corrected.should == false
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'under :safe mode' do
+      let(:autocorrect) { :safe }
+      let(:haml) { '%tag(lang=en)' }
+
+      it 'reports the lint but does not correct it' do
+        subject
+        subject.lints.first.corrected.should == false
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when there is nothing to correct' do
+      let(:haml) { "%tag{ lang: 'en' }" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the linter is disabled inline' do
+      let(:haml) { "-# haml-lint:disable HtmlAttributes\n%tag(lang=en)" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+  end
 end

--- a/spec/haml_lint/linter/unnecessary_string_output_spec.rb
+++ b/spec/haml_lint/linter/unnecessary_string_output_spec.rb
@@ -149,4 +149,120 @@ describe HamlLint::Linter::UnnecessaryStringOutput do
 
     it { should_not report_lint }
   end
+
+  context 'with autocorrect' do
+    let(:autocorrect) { :all }
+
+    context 'when a tag outputs a string with interpolation' do
+      let(:haml) { '%tag= "Some #{interpolation} text"' }
+
+      it 'rewrites it as inline plain text' do
+        subject
+        document.source.should == '%tag Some #{interpolation} text'
+      end
+
+      it 'records the lint as corrected' do
+        subject
+        subject.lints.size.should == 1
+        subject.lints.first.corrected.should == true
+      end
+    end
+
+    context 'when the tag has attributes' do
+      let(:haml) { '%p.foo{ id: "x" }= "bar #{value}"' }
+
+      it 'preserves the tag, classes and attributes' do
+        subject
+        document.source.should == '%p.foo{ id: "x" } bar #{value}'
+      end
+    end
+
+    context 'when a script outputs a double-quoted string with interpolation' do
+      let(:haml) { '= "hello #{world}"' }
+
+      it 'rewrites it as plain text' do
+        subject
+        document.source.should == 'hello #{world}'
+      end
+    end
+
+    context 'when a script outputs a single-quoted literal string' do
+      let(:haml) { "= 'hello world'" }
+
+      it 'rewrites it as plain text' do
+        subject
+        document.source.should == 'hello world'
+      end
+    end
+
+    context 'when a script outputs a string starting with interpolation' do
+      let(:haml) { '= "#{variable}"' }
+
+      it 'rewrites it as plain text, keeping the interpolation' do
+        subject
+        document.source.should == '#{variable}'
+      end
+    end
+
+    context 'when a single-quoted literal contains interpolation syntax' do
+      let(:haml) { %q(= 'a #{foo} b') }
+
+      it 'escapes the interpolation so it stays literal' do
+        subject
+        document.source.should == 'a \#{foo} b'
+      end
+    end
+
+    context 'when the script is nested under a tag' do
+      let(:haml) { <<-'HAML' }
+        %div
+          = "hello #{world}"
+      HAML
+
+      it 'rewrites it as plain text while preserving indentation' do
+        subject
+        document.source.should == "%div\n  hello \#{world}\n"
+      end
+    end
+
+    context 'when the tag outputs unescaped HTML' do
+      let(:haml) { '%tag!= "un #{safe}"' }
+
+      it 'reports the lint but does not change the unescaped output' do
+        subject
+        subject.lints.size.should == 1
+        subject.lints.first.corrected.should == false
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'under :safe mode' do
+      let(:autocorrect) { :safe }
+      let(:haml) { '= "hello #{world}"' }
+
+      it 'reports the lint but does not correct it' do
+        subject
+        subject.lints.first.corrected.should == false
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when there is nothing to correct' do
+      let(:haml) { '%tag Some inline text' }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+
+    context 'when the linter is disabled inline' do
+      let(:haml) { "-# haml-lint:disable UnnecessaryStringOutput\n= \"hello\"" }
+
+      it 'does not change the source' do
+        subject
+        document.source_was_changed.should == false
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds unsafe auto-correction (applied only under `-A` / `--auto-correct-all`) to four Haml-level linters that previously flagged issues without being able to fix them. Each correction is behavior-preserving in the common case and **bails out (reporting without correcting)** whenever it can't guarantee an equivalent rewrite.

Along the way, two latent bugs were found and fixed (see below).

## Linters gaining auto-correction

| Linter | Before | After |
| --- | --- | --- |
| **UnnecessaryStringOutput** | `%tag= "Some #{x}"` | `%tag Some #{x}` |
| **HtmlAttributes** | `%tag(href="x" data=foo)` | `%tag{ "href" => "x", "data" => foo }` |
| **ConsecutiveSilentScripts** | consecutive `- a` / `- b` / `- c` | a single `:ruby` filter block |
| **AlignmentTabs** | `%p⇥Hello` | `%p Hello` |

### Safety notes per linter

- **UnnecessaryStringOutput** — rebuilds the plain text from the parsed string literal, keeping `#{...}` interpolation and escaping literal `#{` so Haml won't interpolate it. Keeps the existing equivalence guards (escape sequences, significant whitespace, reserved leading characters) and leaves `!=`/`~` markers alone.
- **HtmlAttributes** — builds the hash from Haml's already-validated parse output. Skips (still reports) cases that can't be converted losslessly: an existing `{...}` group, the `.class`/`#id` shorthand, or a multiline attribute list. Adds `TagNode#static_attributes` to expose the parsed static attributes.
- **ConsecutiveSilentScripts** — merges a run into an equivalent `:ruby` filter, preserving indentation and variable scope. Only merges single-line scripts on contiguous lines.
- **AlignmentTabs** — collapses each run of alignment tabs into one space, leaving indentation tabs untouched.

## Bug fixes included

- **`AlignmentTabs` was never running.** It was missing its `LinterRegistry` registration, so it was never selected during real runs despite being `enabled: true` in the default config. Adding the registration **activates the linter for all users** — worth a callout during review.
- **`ConsecutiveSilentScripts` reported overlapping duplicate lints** for runs longer than `max_consecutive + 1` (e.g. a run of 5 reported 3 overlapping lints). `reported_nodes` was never populated; fixing it also lets the auto-correct apply a single, non-overlapping correction per run.
