### PR TITLE
Add corrected/correctable flags to offense output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Haml-Lint Changelog
 
+### Unreleased
+
+* Add `corrected` and `correctable` flags to each offense in the `json`/`hash` reporter output,
+  mirroring RuboCop's JSON format. `correctable` reports whether an offense could be auto-corrected;
+  for RuboCop offenses it uses RuboCop's own per-offense correctability.
+* Mark correctable-but-uncorrected lints with `[Correctable]` in the default (text) reporter.
+
 ### 0.75.0
 
 * Fix performance regression when using `--parallel` flag

--- a/lib/haml_lint/lint.rb
+++ b/lib/haml_lint/lint.rb
@@ -6,6 +6,9 @@ module HamlLint
     # @return [Boolean] If the error was corrected by auto-correct
     attr_reader :corrected
 
+    # @return [Boolean] If the error could be corrected by auto-correct
+    attr_reader :correctable
+
     # @return [String] file path to which the lint applies
     attr_reader :filename
 
@@ -28,13 +31,14 @@ module HamlLint
     # @param line [Fixnum]
     # @param message [String]
     # @param severity [Symbol]
-    def initialize(linter, filename, line, message, severity = :warning, corrected: false) # rubocop:disable Metrics/ParameterLists
+    def initialize(linter, filename, line, message, severity = :warning, corrected: false, correctable: false) # rubocop:disable Metrics/ParameterLists
       @linter   = linter
       @filename = filename
       @line     = line || 0
       @message  = message
       @severity = Severity.new(severity)
       @corrected = corrected
+      @correctable = correctable
     end
 
     # Return whether this lint has a severity of error.
@@ -45,7 +49,8 @@ module HamlLint
     end
 
     def inspect
-      "#{self.class.name}(corrected=#{corrected}, filename=#{filename}, line=#{line}, " \
+      "#{self.class.name}(corrected=#{corrected}, correctable=#{correctable}, " \
+        "filename=#{filename}, line=#{line}, " \
         "linter=#{linter.class.name}, message=#{message}, severity=#{severity})"
     end
   end

--- a/lib/haml_lint/linter.rb
+++ b/lib/haml_lint/linter.rb
@@ -212,11 +212,14 @@ module HamlLint
     #
     # @param node_or_line [#line] line number or node to extract the line number from
     # @param message [String] error/warning to display to the user
-    def record_lint(node_or_line, message, corrected: false)
+    # @param corrected [Boolean] whether the lint was fixed by auto-correct
+    # @param correctable [Boolean] whether the lint can be fixed by auto-correct;
+    #   defaults to whether this linter supports auto-correct at all
+    def record_lint(node_or_line, message, corrected: false, correctable: supports_autocorrect?)
       line = node_or_line.is_a?(Integer) ? node_or_line : node_or_line.line
       @lints << HamlLint::Lint.new(self, @document.file, line, message,
                                    config.fetch('severity', :warning).to_sym,
-                                   corrected: corrected)
+                                   corrected: corrected, correctable: correctable)
     end
 
     # Parse Ruby code into an abstract syntax tree.

--- a/lib/haml_lint/linter/rubocop.rb
+++ b/lib/haml_lint/linter/rubocop.rb
@@ -282,7 +282,7 @@ module HamlLint
           end
         end
         record_lint(line, offense.message, offense.severity.name,
-                    corrected: autocorrected)
+                    corrected: autocorrected, correctable: offense.correctable?)
       end
     end
 
@@ -291,13 +291,15 @@ module HamlLint
     # @param line [#line] line number of the lint
     # @param message [String] error/warning to display to the user
     # @param severity [Symbol] RuboCop severity level for the offense
-    def record_lint(line, message, severity, corrected:)
+    # @param corrected [Boolean] whether RuboCop auto-corrected the offense
+    # @param correctable [Boolean] whether RuboCop is able to auto-correct the offense
+    def record_lint(line, message, severity, corrected:, correctable: false)
       # TODO: actual handling for RuboCop's new :info severity
       return if severity == :info
 
       @lints << HamlLint::Lint.new(self, @document.file, line, message,
                                    SEVERITY_MAP.fetch(severity, :warning),
-                                   corrected: corrected)
+                                   corrected: corrected, correctable: correctable)
     end
 
     # rubocop:disable Style/MutableConstant

--- a/lib/haml_lint/reporter/hash_reporter.rb
+++ b/lib/haml_lint/reporter/hash_reporter.rb
@@ -47,6 +47,8 @@ module HamlLint
       {
         severity: offense.severity,
         message: offense.message,
+        corrected: offense.corrected,
+        correctable: offense.correctable,
         location: {
           line: offense.line,
         },

--- a/lib/haml_lint/reporter/utils.rb
+++ b/lib/haml_lint/reporter/utils.rb
@@ -58,6 +58,8 @@ module HamlLint
       def print_message(lint)
         if lint.corrected
           log.success('[Corrected] ', false)
+        elsif lint.correctable
+          log.info('[Correctable] ', false)
         end
 
         if lint.linter

--- a/lib/haml_lint/spec/matchers/report_lint.rb
+++ b/lib/haml_lint/spec/matchers/report_lint.rb
@@ -11,10 +11,11 @@ module HamlLint
         expected_message = options[:message]
         expected_severity = options[:severity]
         expected_corrected = options[:corrected]
+        expected_correctable = options[:correctable]
 
         match do |linter|
           has_lints?(linter, expected_line, count, expected_message, expected_severity,
-                     expected_corrected)
+                     expected_corrected, expected_correctable)
         end
 
         failure_message do |linter|
@@ -66,14 +67,15 @@ module HamlLint
         end
 
         def has_lints?(linter, expected_line, count, expected_message, expected_severity, # rubocop:disable Metrics/ParameterLists,Naming
-                       expected_corrected)
+                       expected_corrected, expected_correctable)
           if expected_line
             has_expected_line_lints?(linter,
                                      expected_line,
                                      count,
                                      expected_message,
                                      expected_severity,
-                                     expected_corrected)
+                                     expected_corrected,
+                                     expected_correctable)
           elsif count
             linter.lints.count == count
           elsif expected_message
@@ -88,7 +90,8 @@ module HamlLint
                                      count,
                                      expected_message,
                                      expected_severity,
-                                     expected_corrected)
+                                     expected_corrected,
+                                     expected_correctable)
           if count
             multiple_lints_match_line?(linter, expected_line, count)
           elsif expected_message
@@ -97,6 +100,8 @@ module HamlLint
             lint_on_line_matches_severity?(linter, expected_line, expected_severity)
           elsif !expected_corrected.nil?
             lint_on_line_matches_corrected?(linter, expected_line, expected_corrected)
+          elsif !expected_correctable.nil?
+            lint_on_line_matches_correctable?(linter, expected_line, expected_correctable)
           else
             lint_lines(linter).include?(expected_line)
           end
@@ -124,6 +129,12 @@ module HamlLint
           linter
             .lints
             .any? { |lint| lint.line == expected_line && lint.corrected == expected_corrected }
+        end
+
+        def lint_on_line_matches_correctable?(linter, expected_line, expected_correctable)
+          linter
+            .lints
+            .any? { |lint| lint.line == expected_line && lint.correctable == expected_correctable }
         end
 
         def lint_messages_match?(linter, expected_message)

--- a/spec/haml_lint/linter/rubocop_spec.rb
+++ b/spec/haml_lint/linter/rubocop_spec.rb
@@ -38,14 +38,31 @@ describe HamlLint::Linter::RuboCop do
       let(:message) { 'Lint message' }
       let(:cop_name) { 'Style/StringLiterals' }
       let(:severity) { double('Severity', name: :warning) }
+      let(:correctable) { true }
 
       let(:offence) do
         double('offence', line: line, message: message, cop_name: cop_name,
-               severity: severity, status: :uncorrected)
+               severity: severity, status: :uncorrected, correctable?: correctable)
       end
 
       it 'uses the source map to transform line numbers' do
         subject.should report_lint line: 2
+      end
+
+      it 'marks the lint as not corrected' do
+        subject.should report_lint line: 2, corrected: false
+      end
+
+      it 'marks the lint as correctable when the cop supports autocorrect' do
+        subject.should report_lint line: 2, correctable: true
+      end
+
+      context 'and the offence is not correctable' do
+        let(:correctable) { false }
+
+        it 'marks the lint as not correctable' do
+          subject.should report_lint line: 2, correctable: false
+        end
       end
 
       context 'and the offence is from an ignored cop' do

--- a/spec/haml_lint/reporter/default_reporter_spec.rb
+++ b/spec/haml_lint/reporter/default_reporter_spec.rb
@@ -101,6 +101,40 @@ describe HamlLint::Reporter::DefaultReporter do
           end
         end
       end
+
+      context 'when a lint is correctable but not corrected' do
+        let(:lints) do
+          [HamlLint::Lint.new(linter, filenames.first, lines.first, descriptions.first,
+                              :warning, correctable: true)]
+        end
+
+        it 'marks the lint as [Correctable]' do
+          subject
+          output.scan(/\[Correctable\]/).count.should == 1
+        end
+
+        it 'does not mark the lint as [Corrected]' do
+          subject
+          output.should_not include('[Corrected]')
+        end
+      end
+
+      context 'when a lint is corrected' do
+        let(:lints) do
+          [HamlLint::Lint.new(linter, filenames.first, lines.first, descriptions.first,
+                              :warning, corrected: true, correctable: true)]
+        end
+
+        it 'marks the lint as [Corrected]' do
+          subject
+          output.scan(/\[Corrected\]/).count.should == 1
+        end
+
+        it 'does not also mark the lint as [Correctable]' do
+          subject
+          output.should_not include('[Correctable]')
+        end
+      end
     end
   end
 

--- a/spec/haml_lint/reporter/json_reporter_spec.rb
+++ b/spec/haml_lint/reporter/json_reporter_spec.rb
@@ -75,6 +75,37 @@ describe HamlLint::Reporter::JsonReporter do
         offenses.map { |o| o['linter_name'] }.uniq.should eq [linter.name]
       end
 
+      it 'has the corrected flag for each lint' do
+        subject
+        offenses.map { |o| o['corrected'] }.should eq [false, false]
+      end
+
+      it 'has the correctable flag for each lint' do
+        subject
+        offenses.map { |o| o['correctable'] }.should eq [false, false]
+      end
+
+      context 'when lints are corrected and correctable' do
+        let(:lints) do
+          filenames.each_with_index.map do |filename, index|
+            HamlLint::Lint.new(linter, filename, lines[index], descriptions[index],
+                               severities[index], corrected: index.even?, correctable: true)
+          end
+        end
+
+        it 'reflects the corrected flag for each lint' do
+          subject
+          offenses_for = ->(name) { output['files'].find { |f| f['path'] == name }['offenses'] }
+          offenses_for.call(filenames[0]).first['corrected'].should eq true
+          offenses_for.call(filenames[1]).first['corrected'].should eq false
+        end
+
+        it 'reflects the correctable flag for each lint' do
+          subject
+          offenses.map { |o| o['correctable'] }.uniq.should eq [true]
+        end
+      end
+
       it_behaves_like 'output format specification'
 
       context 'when lint has no associated linter' do

--- a/spec/haml_lint/runner_spec.rb
+++ b/spec/haml_lint/runner_spec.rb
@@ -216,6 +216,10 @@ describe HamlLint::Runner do
         subject.lints.size.should be >= 1
       end
 
+      it 'reports the corrected offenses as correctable' do
+        subject.lints.all?(&:correctable).should == true
+      end
+
       context 'under :all mode' do
         let(:autocorrect) { :all }
 


### PR DESCRIPTION
## Summary

Brings haml-lint's output to parity with RuboCop's JSON format by adding two per-offense flags:

- **`corrected`** — whether the offense was fixed by auto-correct (already tracked internally, now surfaced).
- **`correctable`** — whether the offense *could* be auto-corrected (new).

This mirrors what `rubocop -f json` reports for the same embedded Ruby (e.g. `"corrected": false, "correctable": true`).

## Output examples

Given `- if some_var = value` in a template, `haml-lint -r json` now emits per offense:

```json
{
  "severity": "warning",
  "message": "Lint/AssignmentInCondition: Use `==` if ...",
  "corrected": false,
  "correctable": true,
  "location": { "line": 1 },
  "linter_name": "RuboCop"
}
```

The default text reporter marks correctable-but-uncorrected lints with `[Correctable]`, alongside the existing `[Corrected]`:

```
verify.haml:1 [W] [Correctable] RuboCop: Lint/AssignmentInCondition: Use `==` if you meant to do a comparison ...
verify.haml:2 [W] [Correctable] TrailingWhitespace: Line contains trailing whitespace
```

Running with `-a`, a fixed offense flips to `corrected: true` (and `[Corrected]` in text):

```json
{ "message": "Line contains trailing whitespace", "corrected": true, "correctable": true, "location": { "line": 2 } }
```

## How

- `Lint` gains a `correctable` attribute alongside `corrected`.
- Base `record_lint` defaults `correctable` to the linter's `supports_autocorrect?`, so every HAML linter is covered without editing each file. A linter can pass `correctable: false` for offenses it can't fix.
- The RuboCop linter threads RuboCop's own per-offense `offense.correctable?`, correctly distinguishing cops that support autofix from those that don't (rather than assuming the whole linter is correctable).
- Syntax/processing errors stay `correctable: false`.
