### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/haml_lint.gemspec
+++ b/haml_lint.gemspec
@@ -33,5 +33,6 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/sds/haml-lint/issues',
     'changelog_uri' => 'https://github.com/sds/haml-lint/blob/main/CHANGELOG.md',
     'source_code_uri' => 'https://github.com/sds/haml-lint',
+    'rubygems_mfa_required' => 'true',
   }
 end


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations
by any of the owners require OTP.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/