### PR TITLE
Configure monthly GitHub Actions Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,8 @@
 
 version: 2
 updates:
-  - package-ecosystem: bundler
-    directory: '/'
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7
-    open-pull-requests-limit: 99
-
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: daily
-    cooldown:
-      default-days: 7
+      interval: monthly
     open-pull-requests-limit: 99


### PR DESCRIPTION
- limit Dependabot to GitHub Actions updates
- run GitHub Actions updates monthly