### PR TITLE
Relax `haml` gem constraint to not have an upper bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Haml-Lint Changelog
 
+### Unreleased
+
+* Relax `haml` gem constraint to not have an upper bound, so we're not blocking usage when new Haml versions are released
+
 ### 0.76.0
 
 * Add unsafe auto-correction (run only under `-A`/`--auto-correct-all`) to `UnnecessaryStringOutput`, `HtmlAttributes`, `ConsecutiveSilentScripts`, and `AlignmentTabs`

--- a/lib/haml_lint/adapter.rb
+++ b/lib/haml_lint/adapter.rb
@@ -18,21 +18,18 @@ module HamlLint
     def self.detect_class
       version = haml_version
       case version
-      when '~> 5.0', '~> 5.1', '~> 5.2' then HamlLint::Adapter::Haml5
-      when '~> 6.0', '~> 6.0.a', '~> 6.1', '~> 6.2', '~> 6.3', '~> 6.4' then HamlLint::Adapter::Haml6
-      when '~> 7.0', '~> 7.1', '~> 7.2' then HamlLint::Adapter::Haml6
+      when Gem::Requirement.new('~> 5.0') then HamlLint::Adapter::Haml5
+      when Gem::Requirement.new('>= 6.0.a') then HamlLint::Adapter::Haml6
       else fail HamlLint::Exceptions::UnknownHamlVersion, "Cannot handle Haml version: #{version}"
       end
     end
 
-    # Determines the approximate version of Haml that is installed
+    # Determines the version of Haml that is installed
     #
     # @api private
-    # @return [String] the approximate Haml version
+    # @return [Gem::Version] the Haml version
     def self.haml_version
-      Gem::Version
-        .new(Haml::VERSION)
-        .approximate_recommendation
+      Gem::Version.new(Haml::VERSION)
     end
     private_class_method :haml_version
   end

--- a/spec/haml_lint/adapter_spec.rb
+++ b/spec/haml_lint/adapter_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe HamlLint::Adapter do
       it { should == HamlLint::Adapter::Haml6 }
     end
 
+    context 'on Haml 7' do
+      before { stub_const('Haml::VERSION', '7.3.0') }
+
+      it { should == HamlLint::Adapter::Haml6 }
+    end
+
+    context 'on a future version of Haml' do
+      before { stub_const('Haml::VERSION', '8.0.0') }
+
+      it { should == HamlLint::Adapter::Haml6 }
+    end
+
     context 'on unknown version of Haml' do
       before { stub_const('Haml::VERSION', '4.0.0') }
 


### PR DESCRIPTION
Ensures we don't keep getting issues related to a new Haml release not being supported by Haml-Lint, unless there's an actual breakage.

Fixes #689